### PR TITLE
Add Maven Java stream bot skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# StreamBot
+
+Aplicaci\u00f3n Java basada en Maven que utiliza un modelo de lenguaje y Twitch4J para interactuar con el p\u00fablico de un stream. Incluye ejemplos b\u00e1sicos para conectar con Twitch y generar preguntas usando la API de OpenAI.
+
+## Importar en IntelliJ
+1. Desde IntelliJ seleccione **File \u2192 Open** y elija la carpeta del proyecto.
+2. IntelliJ detectar\u00e1 el `pom.xml` y configur\u00e1 autom\u00e1ticamente las dependencias.
+
+## Compilar y ejecutar
+```bash
+mvn package
+java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication
+```
+
+## Configuraci\u00f3n de credenciales
+Cree un archivo `.env` en la ra\u00edz con las siguientes variables:
+
+```
+OPENAI_API_KEY=su_clave_de_openai
+TWITCH_OAUTH_TOKEN=oauth:sutoken
+TWITCH_CHANNEL=nombre_del_canal
+```
+
+La primera prueba es ejecutar la aplicaci\u00f3n y en el chat de Twitch escribir `!topic` para recibir una pregunta generada por el modelo.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>streambot</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.theokanning.openai-gpt3-java</groupId>
+            <artifactId>client</artifactId>
+            <version>0.18.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.twitch4j</groupId>
+            <artifactId>twitch4j</artifactId>
+            <version>1.25.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.1.0-alpha1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/com/example/streambot/ChatBot.java
+++ b/src/main/java/com/example/streambot/ChatBot.java
@@ -1,0 +1,48 @@
+package com.example.streambot;
+
+import com.github.twitch4j.TwitchClient;
+import com.github.twitch4j.TwitchClientBuilder;
+import com.github.twitch4j.chat.events.channel.ChannelMessageEvent;
+import com.github.twitch4j.auth.providers.OAuth2Credential;
+import io.github.cdimascio.dotenv.Dotenv;
+
+public class ChatBot {
+    private final TwitchClient client;
+    private final OpenAIService aiService;
+
+    public ChatBot() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String token = dotenv.get("TWITCH_OAUTH_TOKEN");
+        String channel = dotenv.get("TWITCH_CHANNEL");
+
+        client = TwitchClientBuilder.builder()
+                .withEnableChat(true)
+                .withChatAccount(oauthCredential(token))
+                .build();
+        aiService = new OpenAIService();
+
+        client.getEventManager().onEvent(ChannelMessageEvent.class, event -> {
+            if (event.getChannel().getName().equalsIgnoreCase(channel)) {
+                handleMessage(event);
+            }
+        });
+    }
+
+    private static OAuth2Credential oauthCredential(String token) {
+        return new OAuth2Credential("twitch", token);
+    }
+
+    private void handleMessage(ChannelMessageEvent event) {
+        // Example: when someone types !topic ask OpenAI for a question
+        if (event.getMessage().startsWith("!topic")) {
+            String response = aiService.ask("Give me an interesting question for a livestream audience.");
+            client.getChat().sendMessage(event.getChannel().getName(), response);
+        }
+    }
+
+    public void start() {
+        // join channel defined in .env
+        String channel = Dotenv.load().get("TWITCH_CHANNEL");
+        client.getChat().joinChannel(channel);
+    }
+}

--- a/src/main/java/com/example/streambot/OpenAIService.java
+++ b/src/main/java/com/example/streambot/OpenAIService.java
@@ -1,0 +1,27 @@
+package com.example.streambot;
+
+import com.theokanning.openai.service.OpenAiService;
+import com.theokanning.openai.completion.CompletionRequest;
+import io.github.cdimascio.dotenv.Dotenv;
+
+public class OpenAIService {
+    private final OpenAiService service;
+
+    public OpenAIService() {
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        String apiKey = dotenv.get("OPENAI_API_KEY");
+        service = new OpenAiService(apiKey);
+    }
+
+    public String ask(String prompt) {
+        CompletionRequest request = CompletionRequest.builder()
+                .prompt(prompt)
+                .model("text-davinci-003")
+                .maxTokens(50)
+                .build();
+        return service.createCompletion(request)
+                .getChoices()
+                .get(0)
+                .getText();
+    }
+}

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -1,0 +1,9 @@
+package com.example.streambot;
+
+public class StreamBotApplication {
+    public static void main(String[] args) {
+        // Initialize and start the bot
+        ChatBot bot = new ChatBot();
+        bot.start();
+    }
+}


### PR DESCRIPTION
## Summary
- initialize Maven project structure
- add OpenAI, Twitch4J, dotenv and SLF4J dependencies
- implement basic StreamBot application with OpenAI service and Twitch chat logic
- document usage and credentials in README

## Testing
- `mvn -q -e -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483e803338832c860b6a5d2fa7e570