### PR TITLE
Add local OpenAI-only mode

### DIFF
--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -1,0 +1,35 @@
+package com.example.streambot;
+
+import java.util.Scanner;
+
+/**
+ * A simple console-based chatbot that interacts with OpenAI directly
+ * without connecting to Twitch.
+ */
+public class LocalChatBot {
+    private final OpenAIService aiService;
+
+    public LocalChatBot() {
+        this.aiService = new OpenAIService();
+    }
+
+    /**
+     * Start a simple REPL that sends user input to OpenAI and prints the response.
+     */
+    public void start() {
+        try (Scanner scanner = new Scanner(System.in)) {
+            System.out.println("Local ChatBot started. Type 'exit' to quit.");
+            while (scanner.hasNextLine()) {
+                String input = scanner.nextLine().trim();
+                if (input.equalsIgnoreCase("exit") || input.equalsIgnoreCase("quit")) {
+                    break;
+                }
+                if (input.isEmpty()) {
+                    continue;
+                }
+                String response = aiService.ask(input);
+                System.out.println("AI: " + response);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -1,9 +1,18 @@
 package com.example.streambot;
 
+import io.github.cdimascio.dotenv.Dotenv;
+
 public class StreamBotApplication {
     public static void main(String[] args) {
-        // Initialize and start the bot
-        ChatBot bot = new ChatBot();
-        bot.start();
+        Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
+        boolean useTwitch = Boolean.parseBoolean(dotenv.get("USE_TWITCH", "true"));
+
+        if (useTwitch) {
+            ChatBot bot = new ChatBot();
+            bot.start();
+        } else {
+            LocalChatBot bot = new LocalChatBot();
+            bot.start();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- allow running without Twitch via new `LocalChatBot`
- switch between Twitch and local modes using new `USE_TWITCH` flag

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684841a32a7c832c9156bef4deaa05b4