### PR TITLE
Expand README with Maven instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,33 @@
 
 Aplicaci\u00f3n Java basada en Maven que utiliza un modelo de lenguaje y Twitch4J para interactuar con el p\u00fablico de un stream. Incluye ejemplos b\u00e1sicos para conectar con Twitch y generar preguntas usando la API de OpenAI.
 
+## Instalaci\u00f3n de Maven
+
+Si Maven no est\u00e1 instalado en su sistema puede hacerlo siguiendo alguno de estos m\u00e9todos:
+
+### Ubuntu/Debian
+
+```bash
+sudo apt-get update
+sudo apt-get install maven
+```
+
+### macOS con Homebrew
+
+```bash
+brew install maven
+```
+
+### Windows
+
+Descargue el binario desde [la p\u00e1gina oficial de Maven](https://maven.apache.org/download.cgi), descompr\u00edmalo y agregue la ruta `bin` a la variable de entorno `PATH`.
+
+Para verificar la instalaci\u00f3n ejecute:
+
+```bash
+mvn -v
+```
+
 ## Importar en IntelliJ
 1. Desde IntelliJ seleccione **File \u2192 Open** y elija la carpeta del proyecto.
 2. IntelliJ detectar\u00e1 el `pom.xml` y configur\u00e1 autom\u00e1ticamente las dependencias.
@@ -11,6 +38,16 @@ Aplicaci\u00f3n Java basada en Maven que utiliza un modelo de lenguaje y Twitch4
 mvn package
 java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication
 ```
+
+### Ejecutar solo para OBS
+
+Cuando el proyecto incluya soporte para este modo se podr\u00e1 iniciar el bot sin conectarse a Twitch utilizando:
+
+```bash
+java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication --obs-only
+```
+
+Este comando generar\u00e1 las respuestas del chat para mostrarlas exclusivamente en OBS.
 
 ## Configuraci\u00f3n de credenciales
 Cree un archivo `.env` en la ra\u00edz con las siguientes variables:


### PR DESCRIPTION
## Summary
- document how to install Maven on different operating systems
- explain how to launch the bot in OBS-only mode

## Testing
- `mvn -version`
- `mvn -q test` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_684841a72dfc832cb2c345632d5a7639