### PR TITLE
Add interactive setup and CLI overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,17 @@ java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplic
 
 Este comando generar\u00e1 las respuestas del chat para mostrarlas exclusivamente en OBS.
 
+También es posible sobrescribir las credenciales al iniciar el programa:
+
+```bash
+java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication 
+  --openai-key TU_CLAVE --twitch-token oauth:token --channel micanal
+```
+
+
 ## Configuraci\u00f3n de credenciales
-Cree un archivo `.env` en la ra\u00edz con las siguientes variables:
+Si no existe, al iniciar se mostrará un asistente interactivo para generarlo automáticamente.
+También puedes crear el archivo `.env` manualmente en la raíz con las siguientes variables (puede copiar `env.example` y completar los valores):
 
 ```
 OPENAI_API_KEY=su_clave_de_openai

--- a/env.example
+++ b/env.example
@@ -1,0 +1,7 @@
+# Example configuration for StreamBot
+OPENAI_API_KEY=
+TWITCH_OAUTH_TOKEN=
+TWITCH_CHANNEL=
+# OPENAI_BASE_URL=https://api.openai.com/
+# OPENAI_MODEL=text-davinci-003
+# USE_TWITCH=true

--- a/src/main/java/com/example/streambot/ChatBot.java
+++ b/src/main/java/com/example/streambot/ChatBot.java
@@ -17,8 +17,8 @@ public class ChatBot {
 
     public ChatBot() {
         this.dotenv = Dotenv.configure().ignoreIfMissing().load();
-        String token = dotenv.get("TWITCH_OAUTH_TOKEN");
-        String channel = dotenv.get("TWITCH_CHANNEL");
+        String token = getProperty("TWITCH_OAUTH_TOKEN");
+        String channel = getProperty("TWITCH_CHANNEL");
 
         if (token == null || token.isBlank() || channel == null || channel.isBlank()) {
             logger.error("TWITCH_OAUTH_TOKEN or TWITCH_CHANNEL missing; skipping Twitch connection.");
@@ -28,6 +28,8 @@ public class ChatBot {
                     .withEnableChat(true)
                     .withChatAccount(oauthCredential(token))
                     .build();
+
+            logger.info("Conectando a Twitch en el canal {}", channel);
 
             client.getEventManager().onEvent(ChannelMessageEvent.class, event -> {
                 if (event.getChannel().getName().equalsIgnoreCase(channel)) {
@@ -54,7 +56,16 @@ public class ChatBot {
         if (client == null) {
             return;
         }
-        String channel = dotenv.get("TWITCH_CHANNEL");
+        String channel = getProperty("TWITCH_CHANNEL");
+        logger.info("Uni\u00e9ndose al canal {}", channel);
         client.getChat().joinChannel(channel);
+    }
+
+    private String getProperty(String key) {
+        String value = System.getProperty(key);
+        if (value == null || value.isBlank()) {
+            value = dotenv.get(key);
+        }
+        return value;
     }
 }

--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -1,12 +1,15 @@
 package com.example.streambot;
 
 import java.util.Scanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A simple console-based chatbot that interacts with OpenAI directly
  * without connecting to Twitch.
  */
 public class LocalChatBot {
+    private static final Logger logger = LoggerFactory.getLogger(LocalChatBot.class);
     private final OpenAIService aiService;
 
     public LocalChatBot() {
@@ -18,7 +21,7 @@ public class LocalChatBot {
      */
     public void start() {
         try (Scanner scanner = new Scanner(System.in)) {
-            System.out.println("Local ChatBot started. Type 'exit' to quit.");
+            logger.info("Local ChatBot started. Type 'exit' to quit.");
             while (scanner.hasNextLine()) {
                 String input = scanner.nextLine().trim();
                 if (input.equalsIgnoreCase("exit") || input.equalsIgnoreCase("quit")) {

--- a/src/main/java/com/example/streambot/OpenAIService.java
+++ b/src/main/java/com/example/streambot/OpenAIService.java
@@ -9,15 +9,18 @@ import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
 import retrofit2.converter.jackson.JacksonConverterFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.time.Duration;
 
 public class OpenAIService {
+    private static final Logger logger = LoggerFactory.getLogger(OpenAIService.class);
     private final OpenAiService service;
 
     public OpenAIService() {
         Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
-        String apiKey = dotenv.get("OPENAI_API_KEY");
-        String baseUrl = dotenv.get("OPENAI_BASE_URL", "https://api.openai.com/");
+        String apiKey = getProperty("OPENAI_API_KEY", dotenv);
+        String baseUrl = getProperty("OPENAI_BASE_URL", dotenv, "https://api.openai.com/");
 
         OkHttpClient client = OpenAiService.defaultClient(apiKey, Duration.ofSeconds(60));
         ObjectMapper mapper = OpenAiService.defaultObjectMapper();
@@ -29,11 +32,12 @@ public class OpenAIService {
                 .build();
         OpenAiApi api = retrofit.create(OpenAiApi.class);
         service = new OpenAiService(api, client.dispatcher().executorService());
+        logger.info("OpenAIService inicializado usando {}", baseUrl);
     }
 
     public String ask(String prompt) {
         Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
-        String model = dotenv.get("OPENAI_MODEL", "text-davinci-003");
+        String model = getProperty("OPENAI_MODEL", dotenv, "text-davinci-003");
 
         CompletionRequest request = CompletionRequest.builder()
                 .prompt(prompt)
@@ -44,5 +48,18 @@ public class OpenAIService {
                 .getChoices()
                 .get(0)
                 .getText();
+    }
+
+    private String getProperty(String key, Dotenv dotenv) {
+        String val = System.getProperty(key);
+        if (val == null || val.isBlank()) {
+            val = dotenv.get(key);
+        }
+        return val;
+    }
+
+    private String getProperty(String key, Dotenv dotenv, String def) {
+        String val = getProperty(key, dotenv);
+        return val != null ? val : def;
     }
 }

--- a/src/main/java/com/example/streambot/SetupWizard.java
+++ b/src/main/java/com/example/streambot/SetupWizard.java
@@ -1,0 +1,41 @@
+package com.example.streambot;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Scanner;
+
+/**
+ * Simple interactive wizard to create the .env file if it does not exist.
+ */
+public class SetupWizard {
+    /**
+     * Run the wizard if .env is missing.
+     */
+    public static void run() {
+        File env = new File(".env");
+        if (env.exists()) {
+            return;
+        }
+
+        try (Scanner scanner = new Scanner(System.in)) {
+            System.out.println("Configuraci\u00f3n inicial de StreamBot:");
+            System.out.print("OPENAI_API_KEY: ");
+            String apiKey = scanner.nextLine().trim();
+            System.out.print("TWITCH_OAUTH_TOKEN: ");
+            String token = scanner.nextLine().trim();
+            System.out.print("TWITCH_CHANNEL: ");
+            String channel = scanner.nextLine().trim();
+
+            try (PrintWriter out = new PrintWriter(new FileWriter(env))) {
+                out.println("OPENAI_API_KEY=" + apiKey);
+                out.println("TWITCH_OAUTH_TOKEN=" + token);
+                out.println("TWITCH_CHANNEL=" + channel);
+            }
+            System.out.println("Archivo .env creado.\n");
+        } catch (IOException e) {
+            System.err.println("Error al crear .env: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -2,10 +2,20 @@ package com.example.streambot;
 
 import io.github.cdimascio.dotenv.Dotenv;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class StreamBotApplication {
+
     public static void main(String[] args) {
+        SetupWizard.run();
+
+        Map<String, String> cli = parseArgs(args);
+        cli.forEach(System::setProperty);
+
         Dotenv dotenv = Dotenv.configure().ignoreIfMissing().load();
-        boolean useTwitch = Boolean.parseBoolean(dotenv.get("USE_TWITCH", "true"));
+        String useTwitchVal = System.getProperty("USE_TWITCH", dotenv.get("USE_TWITCH", "true"));
+        boolean useTwitch = Boolean.parseBoolean(useTwitchVal);
 
         if (useTwitch) {
             ChatBot bot = new ChatBot();
@@ -14,5 +24,26 @@ public class StreamBotApplication {
             LocalChatBot bot = new LocalChatBot();
             bot.start();
         }
+    }
+
+    private static Map<String, String> parseArgs(String[] args) {
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < args.length; i++) {
+            switch (args[i]) {
+                case "--openai-key" -> {
+                    if (i + 1 < args.length) map.put("OPENAI_API_KEY", args[++i]);
+                }
+                case "--twitch-token" -> {
+                    if (i + 1 < args.length) map.put("TWITCH_OAUTH_TOKEN", args[++i]);
+                }
+                case "--channel" -> {
+                    if (i + 1 < args.length) map.put("TWITCH_CHANNEL", args[++i]);
+                }
+                case "--obs-only" -> map.put("USE_TWITCH", "false");
+                default -> {
+                }
+            }
+        }
+        return map;
     }
 }


### PR DESCRIPTION
## Summary
- create `SetupWizard` to configure `.env` interactively
- support command line overrides (`--openai-key`, `--twitch-token`, `--channel`, `--obs-only`)
- add logging of Twitch channel and OpenAI service
- provide `env.example` template
- document new usage in README

## Testing
- `mvn -q -DskipTests=true package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684849dd82bc832c8743b7eb47040164