### PR TITLE
Add USE_TWITCH explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ TWITCH_OAUTH_TOKEN=oauth:sutoken
 TWITCH_CHANNEL=nombre_del_canal
 ```
 
+### Variable `USE_TWITCH`
+
+Por defecto el bot intenta conectarse a Twitch (`USE_TWITCH=true`). Si se establece `USE_TWITCH=false` la aplicación funcionará únicamente de manera local mostrando las respuestas en consola u OBS.
+
+En el archivo `.env` puede indicarse así:
+
+```
+USE_TWITCH=false
+```
+
+También es posible pasarlo desde la línea de comandos (sobrescribe al valor del `.env`):
+
+```bash
+java -DUSE_TWITCH=false -cp target/streambot-1.0-SNAPSHOT.jar \
+  com.example.streambot.StreamBotApplication
+```
+
+La opción abreviada `--obs-only` tiene el mismo efecto:
+
+```bash
+java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication --obs-only
+```
 La primera prueba es ejecutar la aplicaci\u00f3n y en el chat de Twitch escribir `!topic` para recibir una pregunta generada por el modelo.
 
 ## Uso con modelos locales

--- a/env.example
+++ b/env.example
@@ -4,4 +4,4 @@ TWITCH_OAUTH_TOKEN=
 TWITCH_CHANNEL=
 # OPENAI_BASE_URL=https://api.openai.com/
 # OPENAI_MODEL=text-davinci-003
-# USE_TWITCH=true
+USE_TWITCH=true


### PR DESCRIPTION
## Summary
- document USE_TWITCH usage and CLI flag in README
- enable USE_TWITCH in env.example for reference

## Testing
- `apt-get update >/tmp/apt.log && apt-get install -y maven >/tmp/apt.log && tail -n 20 /tmp/apt.log`
- `mvn -q -DskipTests package >/tmp/mvn.log && tail -n 20 /tmp/mvn.log` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848536ca868832c8b20ddab63f93d01