### PR TITLE
Add CLI options for custom OpenAI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ Este comando generar\u00e1 las respuestas del chat para mostrarlas exclusivament
 También es posible sobrescribir las credenciales al iniciar el programa:
 
 ```bash
-java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication 
-  --openai-key TU_CLAVE --twitch-token oauth:token --channel micanal
+java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication
+  --openai-key TU_CLAVE --twitch-token oauth:token --channel micanal \
+  --openai-base-url http://localhost:11434/v1/ --openai-model mixtral
 ```
 
 
@@ -89,3 +90,4 @@ OPENAI_BASE_URL=http://localhost:11434/v1/
 De manera opcional puedes definir `OPENAI_MODEL` si tu servidor usa un nombre de
 modelo distinto. El resto de la aplicaci\u00f3n funciona igual que con la API de
 OpenAI.
+También puedes pasar estas opciones por línea de comandos usando `--openai-base-url` y `--openai-model`.

--- a/env.example
+++ b/env.example
@@ -2,6 +2,7 @@
 OPENAI_API_KEY=
 TWITCH_OAUTH_TOKEN=
 TWITCH_CHANNEL=
+# Optional custom OpenAI endpoint settings
 # OPENAI_BASE_URL=https://api.openai.com/
 # OPENAI_MODEL=text-davinci-003
 # USE_TWITCH=true

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -33,6 +33,12 @@ public class StreamBotApplication {
                 case "--openai-key" -> {
                     if (i + 1 < args.length) map.put("OPENAI_API_KEY", args[++i]);
                 }
+                case "--openai-base-url" -> {
+                    if (i + 1 < args.length) map.put("OPENAI_BASE_URL", args[++i]);
+                }
+                case "--openai-model" -> {
+                    if (i + 1 < args.length) map.put("OPENAI_MODEL", args[++i]);
+                }
                 case "--twitch-token" -> {
                     if (i + 1 < args.length) map.put("TWITCH_OAUTH_TOKEN", args[++i]);
                 }


### PR DESCRIPTION
## Summary
- allow overriding `OPENAI_BASE_URL` and `OPENAI_MODEL` with new CLI flags
- update usage example and docs
- document optional OpenAI variables in `env.example`

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68485371b00c832cb9388db1c06c44e1