### PR TITLE
Add executable shaded jar build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,10 @@ mvn -v
 2. IntelliJ detectar\u00e1 el `pom.xml` y configur\u00e1 autom\u00e1ticamente las dependencias.
 
 ## Compilar y ejecutar
+Al compilar con Maven se generar\u00e1 el archivo `target/streambot-1.0-SNAPSHOT-shaded.jar`.
 ```bash
 mvn package
-java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication
+java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
 
 ### Ejecutar solo para OBS
@@ -44,7 +45,7 @@ java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplic
 Cuando el proyecto incluya soporte para este modo se podr\u00e1 iniciar el bot sin conectarse a Twitch utilizando:
 
 ```bash
-java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication --obs-only
+java -jar target/streambot-1.0-SNAPSHOT-shaded.jar --obs-only
 ```
 
 Este comando generar\u00e1 las respuestas del chat para mostrarlas exclusivamente en OBS.
@@ -52,7 +53,7 @@ Este comando generar\u00e1 las respuestas del chat para mostrarlas exclusivament
 También es posible sobrescribir las credenciales al iniciar el programa:
 
 ```bash
-java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication 
+java -jar target/streambot-1.0-SNAPSHOT-shaded.jar \
   --openai-key TU_CLAVE --twitch-token oauth:token --channel micanal
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,4 +30,29 @@
             <version>2.1.0-alpha1</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.example.streambot.StreamBotApplication</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
## Summary
- create an executable JAR using `maven-shade-plugin`
- document new jar file in compile instructions

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6848539a1518832caf9b50813c2ce512