### PR TITLE
Add JUnit 5 tests for argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ mvn package
 java -cp target/streambot-1.0-SNAPSHOT.jar com.example.streambot.StreamBotApplication
 ```
 
+## Ejecutar pruebas
+Para correr las pruebas unitarias con Maven utilice:
+
+```bash
+mvn test
+```
+
 ### Ejecutar solo para OBS
 
 Cuando el proyecto incluya soporte para este modo se podr\u00e1 iniciar el bot sin conectarse a Twitch utilizando:

--- a/pom.xml
+++ b/pom.xml
@@ -29,5 +29,11 @@
             <artifactId>slf4j-simple</artifactId>
             <version>2.1.0-alpha1</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -1,0 +1,54 @@
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class StreamBotApplicationTest {
+
+    @SuppressWarnings("unchecked")
+    private Map<String, String> invokeParseArgs(String... args) throws Exception {
+        Method m = StreamBotApplication.class.getDeclaredMethod("parseArgs", String[].class);
+        m.setAccessible(true);
+        return (Map<String, String>) m.invoke(null, (Object) args);
+    }
+
+    @Test
+    public void parsesOpenAIKeyFlag() throws Exception {
+        Map<String, String> result = invokeParseArgs("--openai-key", "abc");
+        assertEquals("abc", result.get("OPENAI_API_KEY"));
+    }
+
+    @Test
+    public void parsesTwitchTokenFlag() throws Exception {
+        Map<String, String> result = invokeParseArgs("--twitch-token", "oauth:xyz");
+        assertEquals("oauth:xyz", result.get("TWITCH_OAUTH_TOKEN"));
+    }
+
+    @Test
+    public void parsesChannelFlag() throws Exception {
+        Map<String, String> result = invokeParseArgs("--channel", "mychan");
+        assertEquals("mychan", result.get("TWITCH_CHANNEL"));
+    }
+
+    @Test
+    public void parsesObsOnlyFlag() throws Exception {
+        Map<String, String> result = invokeParseArgs("--obs-only");
+        assertEquals("false", result.get("USE_TWITCH"));
+    }
+
+    @Test
+    public void parsesAllFlagsTogether() throws Exception {
+        Map<String, String> result = invokeParseArgs(
+                "--openai-key", "k",
+                "--twitch-token", "t",
+                "--channel", "c",
+                "--obs-only"
+        );
+        assertEquals("k", result.get("OPENAI_API_KEY"));
+        assertEquals("t", result.get("TWITCH_OAUTH_TOKEN"));
+        assertEquals("c", result.get("TWITCH_CHANNEL"));
+        assertEquals("false", result.get("USE_TWITCH"));
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 dependency
- add unit tests for `StreamBotApplication.parseArgs`
- document running Maven tests

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684853a445cc832c93536bfe770dfa6c