### PR TITLE
Update slf4j-simple version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.1.0-alpha1</version>
+            <version>2.0.9</version>
         </dependency>
         <dependency>
             <groupId>ai.djl</groupId>


### PR DESCRIPTION
## Summary
- use the stable slf4j-simple 2.0.9 release

## Testing
- `mvn -DskipTests package`

------
https://chatgpt.com/codex/tasks/task_e_684885ddaa98832cac624101005f9d1d