### PR TITLE
Release predictor resources on shutdown

### DIFF
--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -33,6 +33,8 @@ public class LocalChatBot {
                 String response = aiService.ask(input);
                 System.out.println("AI: " + response);
             }
+        } finally {
+            aiService.close();
         }
     }
 }

--- a/src/main/java/com/example/streambot/LocalMistralService.java
+++ b/src/main/java/com/example/streambot/LocalMistralService.java
@@ -21,6 +21,7 @@ import java.nio.file.Paths;
 public class LocalMistralService {
     private static final Logger logger = LoggerFactory.getLogger(LocalMistralService.class);
     private Predictor<String, String> predictor;
+    private ZooModel<String, String> model;
 
     public LocalMistralService() {
         String modelPath = EnvUtils.get("MISTRAL_MODEL_PATH", "model");
@@ -45,7 +46,7 @@ public class LocalMistralService {
                     .optEngine("PyTorch")
                     .optTranslator(translator)
                     .build();
-            ZooModel<String, String> model = ModelZoo.loadModel(criteria);
+            model = ModelZoo.loadModel(criteria);
             predictor = model.newPredictor();
         } catch (Exception e) {
             logger.error("Error loading local model", e);
@@ -64,6 +65,20 @@ public class LocalMistralService {
         } catch (TranslateException e) {
             logger.error("Inference error", e);
             return "";
+        }
+    }
+
+    /**
+     * Release loaded resources.
+     */
+    public void close() {
+        if (predictor != null) {
+            predictor.close();
+            predictor = null;
+        }
+        if (model != null) {
+            model.close();
+            model = null;
         }
     }
 }

--- a/src/test/java/com/example/streambot/LocalMistralServiceTest.java
+++ b/src/test/java/com/example/streambot/LocalMistralServiceTest.java
@@ -1,0 +1,14 @@
+package com.example.streambot;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class LocalMistralServiceTest {
+
+    @Test
+    public void closeDoesNotThrow() {
+        LocalMistralService service = new LocalMistralService();
+        assertDoesNotThrow(service::close);
+    }
+}


### PR DESCRIPTION
## Summary
- store `ZooModel` in `LocalMistralService`
- add `close()` to release predictor and model
- close the service when `LocalChatBot` finishes
- add regression test for the new `close()` method

## Testing
- `mvn -q test` *(tests run: 0)*

------
https://chatgpt.com/codex/tasks/task_e_68488cdfc8c4832ca5bbd027379bae81