### PR TITLE
Expose parseArgs for testing

### DIFF
--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -15,8 +15,8 @@ public class StreamBotApplication {
         bot.start();
     }
 
-    // El test invoca este método por reflexión
-    private static Map<String, String> parseArgs(String[] args) {
+    // Package-private for tests
+    static Map<String, String> parseArgs(String[] args) {
         Map<String, String> map = new HashMap<>();
         for (int i = 0; i < args.length; i++) {
             if ("--model-path".equals(args[i]) && i + 1 < args.length) {

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -3,23 +3,15 @@ package com.example.streambot;
 import com.example.streambot.StreamBotApplication;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class StreamBotApplicationTest {
 
-    @SuppressWarnings("unchecked")
-    private Map<String, String> invokeParseArgs(String... args) throws Exception {
-        Method m = StreamBotApplication.class.getDeclaredMethod("parseArgs", String[].class);
-        m.setAccessible(true);
-        return (Map<String, String>) m.invoke(null, (Object) args);
-    }
-
     @Test
-    public void parsesModelPathFlag() throws Exception {
-        Map<String, String> result = invokeParseArgs("--model-path", "/x");
+    public void parsesModelPathFlag() {
+        Map<String, String> result = StreamBotApplication.parseArgs(new String[]{"--model-path", "/x"});
         assertEquals("/x", result.get("MISTRAL_MODEL_PATH"));
     }
 }


### PR DESCRIPTION
## Summary
- make `StreamBotApplication.parseArgs` package-private
- simplify `StreamBotApplicationTest` to call `parseArgs` directly

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6848a40fdc2c832c9e960d674249f767