### PR TITLE
Increase test coverage for wizard and chatbot

### DIFF
--- a/src/test/java/com/example/streambot/LocalChatBotTest.java
+++ b/src/test/java/com/example/streambot/LocalChatBotTest.java
@@ -1,0 +1,72 @@
+package com.example.streambot;
+
+import org.junit.jupiter.api.Test;
+import sun.misc.Unsafe;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LocalChatBotTest {
+
+    @Test
+    public void replExitsOnExit() throws Exception {
+        LocalChatBot bot = newInstance();
+        DummyService svc = dummyService();
+        setField(bot, "aiService", svc);
+
+        InputStream origIn = System.in;
+        System.setIn(new ByteArrayInputStream("hi\nexit\n".getBytes(StandardCharsets.UTF_8)));
+        try {
+            bot.start();
+        } finally {
+            System.setIn(origIn);
+        }
+
+        assertTrue(svc.closed, "service closed");
+        assertEquals(List.of("hi"), svc.received);
+    }
+
+    private static LocalChatBot newInstance() throws Exception {
+        Field uf = Unsafe.class.getDeclaredField("theUnsafe");
+        uf.setAccessible(true);
+        Unsafe unsafe = (Unsafe) uf.get(null);
+        return (LocalChatBot) unsafe.allocateInstance(LocalChatBot.class);
+    }
+
+    private static DummyService dummyService() throws Exception {
+        Field uf = Unsafe.class.getDeclaredField("theUnsafe");
+        uf.setAccessible(true);
+        Unsafe unsafe = (Unsafe) uf.get(null);
+        DummyService svc = (DummyService) unsafe.allocateInstance(DummyService.class);
+        svc.received = new ArrayList<>();
+        return svc;
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field f = LocalChatBot.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    static class DummyService extends LocalMistralService {
+        List<String> received;
+        boolean closed = false;
+
+        @Override
+        public String ask(String prompt) {
+            received.add(prompt);
+            return "ok";
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/src/test/java/com/example/streambot/SetupWizardTest.java
+++ b/src/test/java/com/example/streambot/SetupWizardTest.java
@@ -1,0 +1,34 @@
+package com.example.streambot;
+
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SetupWizardTest {
+
+    @Test
+    public void runCreatesEnvFile(@TempDir Path tmp) throws Exception {
+        Path env = Path.of(".env");
+        Path backup = tmp.resolve("env.bak");
+        Files.move(env, backup);
+        InputStream originalIn = System.in;
+        try {
+            System.setIn(new ByteArrayInputStream("bar\n".getBytes(StandardCharsets.UTF_8)));
+            SetupWizard.run();
+            assertTrue(Files.exists(env), ".env should be created");
+            String content = Files.readString(env);
+            assertEquals("MISTRAL_MODEL_PATH=bar\n", content);
+        } finally {
+            System.setIn(originalIn);
+            Files.deleteIfExists(env);
+            Files.move(backup, env);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test ensuring SetupWizard creates `.env` when missing
- add LocalChatBot test to simulate REPL user input

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6848a58c6fb0832cb335f33b34a0bf37