### PR TITLE
Fix SetupWizardTest when .env missing

### DIFF
--- a/src/test/java/com/example/streambot/SetupWizardTest.java
+++ b/src/test/java/com/example/streambot/SetupWizardTest.java
@@ -17,6 +17,10 @@ public class SetupWizardTest {
     public void runCreatesEnvFile(@TempDir Path tmp) throws Exception {
         Path env = Path.of(".env");
         Path backup = tmp.resolve("env.bak");
+        boolean existed = Files.exists(env);
+        if (!existed) {
+            Files.createFile(env);
+        }
         Files.move(env, backup);
         InputStream originalIn = System.in;
         try {
@@ -28,7 +32,11 @@ public class SetupWizardTest {
         } finally {
             System.setIn(originalIn);
             Files.deleteIfExists(env);
-            Files.move(backup, env);
+            if (existed) {
+                Files.move(backup, env);
+            } else {
+                Files.deleteIfExists(backup);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle missing `.env` file in `SetupWizardTest`

## Testing
- `mvn -e test`

------
https://chatgpt.com/codex/tasks/task_e_6848bd56c418832cbd72c93ee87325e9