### PR TITLE
Catch unsupported gguf models

### DIFF
--- a/src/main/java/com/example/streambot/LocalMistralService.java
+++ b/src/main/java/com/example/streambot/LocalMistralService.java
@@ -39,8 +39,12 @@ public class LocalMistralService {
         }
         try {
             if (modelPath.endsWith(".gguf") || modelPath.endsWith(".bin")) {
-                ggufModel = new LLModel(Paths.get(modelPath));
-                return;
+                try {
+                    ggufModel = new LLModel(Paths.get(modelPath));
+                    return;
+                } catch (IllegalStateException e) {
+                    logger.warn("Unsupported GGUF model format");
+                }
             }
             Translator<String, String> translator = new Translator<>() {
                 @Override


### PR DESCRIPTION
## Summary
- handle IllegalStateException when initializing `LLModel`
- log a warning for unsupported gguf models

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6848d1378e5c832c98b05dfa46429d4c