### PR TITLE
Document translator placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ C:\Users\Max\AppData\Local\nomic.ai\GPT4All\Meta-Llama-3.1-8B-Instruct-128k-Q4_0
 C:\Users\Max\AppData\Local\nomic.ai\GPT4All\Meta-Llama-3-8B-Instruct.Q4_0.gguf
 ```
 
+## Limitaciones del traductor
+La clase `LocalMistralService` utiliza un traductor muy b\u00e1sico que simplemente
+convierte cada car\u00e1cter en su c\u00f3digo Unicode. Este enfoque solo sirve como
+marcador de posici\u00f3n y no es adecuado para modelos de producci\u00f3n. Para una
+compatibilidad completa con modelos de lenguaje, integra un *tokenizer* real
+(por ejemplo SentencePiece o el que requiera tu modelo).
+
 ## Licencia
 Este proyecto se distribuye bajo los términos de la [licencia MIT](LICENSE).
 

--- a/src/main/java/com/example/streambot/LocalMistralService.java
+++ b/src/main/java/com/example/streambot/LocalMistralService.java
@@ -46,10 +46,14 @@ public class LocalMistralService {
                     logger.warn("Unsupported GGUF model format");
                 }
             }
+            // The following translator performs a very naive tokenization
+            // that simply converts each character to its Unicode code point.
+            // It is intended only as a minimal placeholder for demos and is
+            // not suitable for real production models. Integrate a tokenizer
+            // compatible with your LLM (e.g. SentencePiece) for full support.
             Translator<String, String> translator = new Translator<>() {
                 @Override
                 public NDList processInput(TranslatorContext ctx, String input) {
-                    // Basic tokenization: convert characters to their code points
                     int[] tokens = input.chars().toArray();
                     return new NDList(ctx.getNDManager().create(tokens));
                 }


### PR DESCRIPTION
## Summary
- clarify translator example in LocalMistralService
- document translator limitations and tokenizer suggestion

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6848d20940d8832c9f15d1d261c3ad93