### PR TITLE
Introduce dummy OpenAI service for tests

### DIFF
--- a/src/test/java/com/example/streambot/DummyOpenAIService.java
+++ b/src/test/java/com/example/streambot/DummyOpenAIService.java
@@ -1,0 +1,32 @@
+package com.example.streambot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Dummy implementation of {@link OpenAIService} used in tests to avoid real API calls.
+ */
+public class DummyOpenAIService extends OpenAIService {
+    public final List<String> received = new ArrayList<>();
+    public boolean closed = false;
+    private final String reply;
+
+    public DummyOpenAIService() {
+        this("ok");
+    }
+
+    public DummyOpenAIService(String reply) {
+        this.reply = reply;
+    }
+
+    @Override
+    public String ask(String prompt) {
+        received.add(prompt);
+        return reply;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+}

--- a/src/test/java/com/example/streambot/LocalChatBotTest.java
+++ b/src/test/java/com/example/streambot/LocalChatBotTest.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
+
+// Use a dummy service to avoid hitting the real OpenAI API
+import com.example.streambot.DummyOpenAIService;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -14,7 +16,7 @@ public class LocalChatBotTest {
 
     @Test
     public void replExitsOnExit() throws Exception {
-        DummyService svc = new DummyService();
+        DummyOpenAIService svc = new DummyOpenAIService();
         LocalChatBot bot = new LocalChatBot(svc);
 
         InputStream origIn = System.in;
@@ -29,21 +31,4 @@ public class LocalChatBotTest {
         assertEquals(List.of("hi"), svc.received);
     }
 
-    static class DummyService extends OpenAIService {
-        List<String> received = new ArrayList<>();
-        boolean closed = false;
-
-        DummyService() {}
-
-        @Override
-        public String ask(String prompt) {
-            received.add(prompt);
-            return "ok";
-        }
-
-        @Override
-        public void close() {
-            closed = true;
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- avoid real API calls in tests by creating `DummyOpenAIService`
- use the new dummy service in `LocalChatBotTest`
- keep SetupWizardTest checking `OPENAI_API_KEY` is written

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684a224b25b0832c8584d929fb47b6ca