### PR TITLE
Fix LocalChatBot javadoc

### DIFF
--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -24,7 +24,7 @@ public class LocalChatBot {
     }
 
     /**
-     * Start a simple REPL that sends user input to Mistral and prints the response.
+     * Start a simple REPL that sends user input to OpenAI and prints the response.
      */
     public void start() {
         try (Scanner scanner = new Scanner(System.in)) {


### PR DESCRIPTION
## Summary
- update LocalChatBot.start javadoc to refer to OpenAI

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684a2714ef70832c8a26c70d1956960e