### PR TITLE
Use Jackson for JSON handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
             <version>2.0.9</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.2</version>

--- a/src/main/java/com/example/streambot/OpenAIService.java
+++ b/src/main/java/com/example/streambot/OpenAIService.java
@@ -6,6 +6,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Simple service that sends prompts to the OpenAI Chat Completions API.
@@ -13,18 +18,28 @@ import java.nio.charset.StandardCharsets;
 public class OpenAIService {
     private final HttpClient client = HttpClient.newHttpClient();
     private final String apiKey = EnvUtils.get("OPENAI_API_KEY");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
      * Send a prompt to the OpenAI API and return the assistant's reply.
      * If the API key is missing or an error occurs, an empty string is returned.
      */
+
     public String ask(String prompt) {
         if (apiKey == null || apiKey.isBlank()) {
             return "";
         }
         try {
-            String payload = "{\"model\":\"gpt-3.5-turbo\",\"messages\":[{\"role\":\"user\",\"content\":\""
-                    + escape(prompt) + "\"}]}";
+            Map<String, Object> message = Map.of(
+                    "role", "user",
+                    "content", prompt
+            );
+            Map<String, Object> payloadMap = Map.of(
+                    "model", "gpt-3.5-turbo",
+                    "messages", List.of(message)
+            );
+            String payload = MAPPER.writeValueAsString(payloadMap);
+
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create("https://api.openai.com/v1/chat/completions"))
                     .header("Authorization", "Bearer " + apiKey)
@@ -32,7 +47,7 @@ public class OpenAIService {
                     .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
                     .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            return extractContent(response.body());
+            return parseContent(response.body());
         } catch (InterruptedException | IOException e) {
             Thread.currentThread().interrupt();
             return "";
@@ -44,18 +59,16 @@ public class OpenAIService {
         // nothing to close
     }
 
-    private static String escape(String s) {
-        return s.replace("\\", "\\\\").replace("\"", "\\\"");
-    }
-
-    private static String extractContent(String body) {
-        int idx = body.indexOf("\"content\"");
-        if (idx == -1) return "";
-        int start = body.indexOf('\"', idx + 9);
-        if (start == -1) return "";
-        start++;
-        int end = body.indexOf('\"', start);
-        if (end == -1) return "";
-        return body.substring(start, end).replace("\\n", "\n").trim();
+    private static String parseContent(String body) {
+        try {
+            JsonNode root = MAPPER.readTree(body);
+            JsonNode content = root.path("choices").path(0).path("message").path("content");
+            if (content.isMissingNode()) {
+                return "";
+            }
+            return content.asText().replace("\\n", "\n").trim();
+        } catch (IOException e) {
+            return "";
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add Jackson JSON library
- use `ObjectMapper` to build OpenAI request payload
- parse the response JSON for the assistant message

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684a29e15788832c883afbc683e68373