### PR TITLE
Add Maven CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,20 @@
+name: Maven Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml
+      - name: Run tests
+        run: mvn -B test --file pom.xml


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build with Maven and run tests on pushes and pull requests using Java 17

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684a2d451058832cb54b8a84088ca56e