### PR TITLE
Add configurable OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Al compilar con Maven se generar\u00e1 el archivo `target/streambot-1.0-SNAPSHOT
 mvn package
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
-Antes de ejecutar asegúrate de que la variable `OPENAI_API_KEY` esté disponible en tu entorno o definida en `.env`. También puedes pasarla al iniciar la aplicación con el argumento `--api-key`.
+Antes de ejecutar asegúrate de que las variables `OPENAI_API_KEY` y `OPENAI_MODEL` estén disponibles en tu entorno o definidas en `.env`. También puedes pasarlas al iniciar la aplicación con los argumentos `--api-key` y `--model`. De forma predeterminada se usa `gpt-3.5-turbo` como modelo.
 
 ## Ejecutar pruebas
 Para correr las pruebas unitarias con Maven utilice:
@@ -92,11 +92,12 @@ java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 
 
 ## Configuración de la API de OpenAI
-Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard` para solicitarla automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar la clave cada vez con el argumento `--api-key`. También puedes usar `env.example` como plantilla. El archivo debe contener lo siguiente:
+Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL` (por ejemplo `gpt-4`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard` para solicitar la clave automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes usar `env.example` como plantilla. El archivo debe contener lo siguiente:
 
 ```
 # Example configuration for StreamBot
 OPENAI_API_KEY=
+OPENAI_MODEL=
 ```
 
 ## Licencia

--- a/env.example
+++ b/env.example
@@ -1,2 +1,3 @@
 # Example configuration for StreamBot
 OPENAI_API_KEY=
+OPENAI_MODEL=

--- a/src/main/java/com/example/streambot/OpenAIService.java
+++ b/src/main/java/com/example/streambot/OpenAIService.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class OpenAIService {
     private final HttpClient client;
     private final String apiKey = EnvUtils.get("OPENAI_API_KEY");
+    private final String model = EnvUtils.get("OPENAI_MODEL", "gpt-3.5-turbo");
 
     /** Default constructor using a new HttpClient. */
     public OpenAIService() {
@@ -48,7 +49,7 @@ public class OpenAIService {
                     "content", prompt
             );
             Map<String, Object> payloadMap = Map.of(
-                    "model", "gpt-3.5-turbo",
+                    "model", model,
                     "messages", List.of(message)
             );
             String payload = MAPPER.writeValueAsString(payloadMap);

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -30,6 +30,8 @@ public class StreamBotApplication {
         for (int i = 0; i < args.length; i++) {
             if ("--api-key".equals(args[i]) && i + 1 < args.length) {
                 map.put("OPENAI_API_KEY", args[++i]);
+            } else if ("--model".equals(args[i]) && i + 1 < args.length) {
+                map.put("OPENAI_MODEL", args[++i]);
             }
         }
         return map;

--- a/src/test/java/com/example/streambot/OpenAIServiceTest.java
+++ b/src/test/java/com/example/streambot/OpenAIServiceTest.java
@@ -79,6 +79,7 @@ public class OpenAIServiceTest {
     @AfterEach
     public void clearKey() {
         System.clearProperty("OPENAI_API_KEY");
+        System.clearProperty("OPENAI_MODEL");
     }
 
     @Test
@@ -97,5 +98,17 @@ public class OpenAIServiceTest {
         OpenAIService svc = new OpenAIService(new StubHttpClient(new IOException("boom")));
         String reply = svc.ask("hi");
         assertEquals("", reply);
+    }
+
+    @Test
+    public void usesModelFromEnv() throws Exception {
+        System.setProperty("OPENAI_API_KEY", "key");
+        System.setProperty("OPENAI_MODEL", "gpt-test");
+        HttpResponse<String> resp = new SimpleResponse("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}");
+        OpenAIService svc = new OpenAIService(new StubHttpClient(resp));
+        svc.ask("hi");
+        var field = OpenAIService.class.getDeclaredField("model");
+        field.setAccessible(true);
+        assertEquals("gpt-test", field.get(svc));
     }
 }

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -22,6 +22,12 @@ public class StreamBotApplicationTest {
     }
 
     @Test
+    public void parsesModelFlag() {
+        Map<String, String> result = StreamBotApplication.parseArgs(new String[]{"--model", "bar"});
+        assertEquals("bar", result.get("OPENAI_MODEL"));
+    }
+
+    @Test
     public void mainSkipsWizardIfApiKeyProvided(@TempDir Path tmp) throws Exception {
         Path env = Path.of(".env");
         Path backup = tmp.resolve("env.bak");


### PR DESCRIPTION
## Summary
- add `--model` flag parsing
- configure `OpenAIService` to read `OPENAI_MODEL`
- document model option in README and env.example
- test new functionality

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684a2ea2cf7c832cb4ed4b091a269c17