### PR TITLE
Add configuration loader and tests

### DIFF
--- a/src/main/java/com/example/streambot/Config.java
+++ b/src/main/java/com/example/streambot/Config.java
@@ -1,0 +1,102 @@
+package com.example.streambot;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Simple configuration holder for StreamBot.
+ */
+public class Config {
+    private final String model;
+    private final double temperature;
+    private final double topP;
+    private final int maxTokens;
+    private final List<String> topics;
+    private final String conversationStyle;
+    private final int silenceTimeout;
+
+    private Config(String model, double temperature, double topP, int maxTokens,
+                    List<String> topics, String conversationStyle, int silenceTimeout) {
+        this.model = model;
+        this.temperature = temperature;
+        this.topP = topP;
+        this.maxTokens = maxTokens;
+        this.topics = List.copyOf(topics);
+        this.conversationStyle = conversationStyle;
+        this.silenceTimeout = silenceTimeout;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public double getTemperature() {
+        return temperature;
+    }
+
+    public double getTopP() {
+        return topP;
+    }
+
+    public int getMaxTokens() {
+        return maxTokens;
+    }
+
+    public List<String> getTopics() {
+        return topics;
+    }
+
+    public String getConversationStyle() {
+        return conversationStyle;
+    }
+
+    public int getSilenceTimeout() {
+        return silenceTimeout;
+    }
+
+    /**
+     * Load configuration values from system properties or a .env file.
+     * Defaults are used when a property is not present or cannot be parsed.
+     */
+    public static Config load() {
+        String model = EnvUtils.get("OPENAI_MODEL", "gpt-3.5-turbo");
+        double temperature = parseDouble(EnvUtils.get("OPENAI_TEMPERATURE"), 0.7);
+        double topP = parseDouble(EnvUtils.get("OPENAI_TOP_P"), 0.9);
+        int maxTokens = parseInt(EnvUtils.get("OPENAI_MAX_TOKENS"), 2048);
+        String style = EnvUtils.get("CONVERSATION_STYLE", "neutral");
+        int timeout = parseInt(EnvUtils.get("SILENCE_TIMEOUT"), 30);
+        String topicsProp = EnvUtils.get("PREFERRED_TOPICS", "");
+        List<String> topics = new ArrayList<>();
+        if (topicsProp != null && !topicsProp.isBlank()) {
+            for (String t : topicsProp.split(",")) {
+                String trimmed = t.trim();
+                if (!trimmed.isEmpty()) {
+                    topics.add(trimmed);
+                }
+            }
+        }
+        return new Config(model, temperature, topP, maxTokens, topics, style, timeout);
+    }
+
+    private static double parseDouble(String val, double def) {
+        if (val == null || val.isBlank()) {
+            return def;
+        }
+        try {
+            return Double.parseDouble(val);
+        } catch (NumberFormatException ex) {
+            return def;
+        }
+    }
+
+    private static int parseInt(String val, int def) {
+        if (val == null || val.isBlank()) {
+            return def;
+        }
+        try {
+            return Integer.parseInt(val);
+        } catch (NumberFormatException ex) {
+            return def;
+        }
+    }
+}

--- a/src/main/java/com/example/streambot/OpenAIService.java
+++ b/src/main/java/com/example/streambot/OpenAIService.java
@@ -21,21 +21,19 @@ import org.slf4j.LoggerFactory;
 public class OpenAIService {
     private static final Logger logger = LoggerFactory.getLogger(OpenAIService.class);
     private final HttpClient client;
-    private final String apiKey = EnvUtils.get("OPENAI_API_KEY");
-    private final String model = EnvUtils.get("OPENAI_MODEL", "gpt-3.5-turbo");
-
-    {
-        if (apiKey == null || apiKey.isBlank()) {
-            logger.warn("OPENAI_API_KEY not configured");
-        } else {
-            logger.debug("OPENAI_API_KEY loaded");
-        }
-        logger.debug("Using model: {}", model);
-    }
+    private final String apiKey;
+    private final String model;
 
     /** Default constructor using a new HttpClient. */
     public OpenAIService() {
-        this(HttpClient.newHttpClient());
+        this(HttpClient.newHttpClient(), null);
+    }
+
+    /**
+     * Create a service using the given configuration.
+     */
+    public OpenAIService(Config config) {
+        this(HttpClient.newHttpClient(), config);
     }
 
     /**
@@ -43,7 +41,23 @@ public class OpenAIService {
      * Primarily used for tests.
      */
     OpenAIService(HttpClient client) {
+        this(client, null);
+    }
+
+    OpenAIService(HttpClient client, Config config) {
         this.client = client;
+        this.apiKey = EnvUtils.get("OPENAI_API_KEY");
+        if (config != null && config.getModel() != null && !config.getModel().isBlank()) {
+            this.model = config.getModel();
+        } else {
+            this.model = EnvUtils.get("OPENAI_MODEL", "gpt-3.5-turbo");
+        }
+        if (apiKey == null || apiKey.isBlank()) {
+            logger.warn("OPENAI_API_KEY not configured");
+        } else {
+            logger.debug("OPENAI_API_KEY loaded");
+        }
+        logger.debug("Using model: {}", model);
     }
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -27,7 +27,8 @@ public class StreamBotApplication {
             SetupWizard.run();
         }
 
-        LocalChatBot bot = new LocalChatBot();
+        Config config = Config.load();
+        LocalChatBot bot = new LocalChatBot(new OpenAIService(config));
         bot.start();
     }
 

--- a/src/test/java/com/example/streambot/ConfigTest.java
+++ b/src/test/java/com/example/streambot/ConfigTest.java
@@ -1,0 +1,54 @@
+package com.example.streambot;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigTest {
+
+    @AfterEach
+    public void clear() {
+        System.clearProperty("OPENAI_MODEL");
+        System.clearProperty("OPENAI_TEMPERATURE");
+        System.clearProperty("OPENAI_TOP_P");
+        System.clearProperty("OPENAI_MAX_TOKENS");
+        System.clearProperty("CONVERSATION_STYLE");
+        System.clearProperty("PREFERRED_TOPICS");
+        System.clearProperty("SILENCE_TIMEOUT");
+    }
+
+    @Test
+    public void loadReadsProperties() {
+        System.setProperty("OPENAI_MODEL", "gpt-test");
+        System.setProperty("OPENAI_TEMPERATURE", "0.5");
+        System.setProperty("OPENAI_TOP_P", "0.8");
+        System.setProperty("OPENAI_MAX_TOKENS", "1024");
+        System.setProperty("CONVERSATION_STYLE", "formal");
+        System.setProperty("PREFERRED_TOPICS", "one, two ,three");
+        System.setProperty("SILENCE_TIMEOUT", "15");
+
+        Config cfg = Config.load();
+        assertEquals("gpt-test", cfg.getModel());
+        assertEquals(0.5, cfg.getTemperature());
+        assertEquals(0.8, cfg.getTopP());
+        assertEquals(1024, cfg.getMaxTokens());
+        assertEquals(List.of("one", "two", "three"), cfg.getTopics());
+        assertEquals("formal", cfg.getConversationStyle());
+        assertEquals(15, cfg.getSilenceTimeout());
+    }
+
+    @Test
+    public void loadUsesDefaults() {
+        Config cfg = Config.load();
+        assertEquals("gpt-3.5-turbo", cfg.getModel());
+        assertEquals(0.7, cfg.getTemperature());
+        assertEquals(0.9, cfg.getTopP());
+        assertEquals(2048, cfg.getMaxTokens());
+        assertTrue(cfg.getTopics().isEmpty());
+        assertEquals("neutral", cfg.getConversationStyle());
+        assertEquals(30, cfg.getSilenceTimeout());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `Config` class to centralize runtime settings
- allow `OpenAIService` to read model from `Config`
- wire configuration into `StreamBotApplication`
- cover `Config` behaviour with unit tests

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684aef44105c832c949d68fc560876c2