### PR TITLE
Add config options to OpenAIService payload

### DIFF
--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -13,7 +13,14 @@ public class LocalChatBot {
     private final OpenAIService aiService;
 
     public LocalChatBot() {
-        this(new OpenAIService());
+        this(Config.load());
+    }
+
+    /**
+     * Create a bot using the provided configuration.
+     */
+    public LocalChatBot(Config config) {
+        this(new OpenAIService(config));
     }
 
     /**

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -28,7 +28,7 @@ public class StreamBotApplication {
         }
 
         Config config = Config.load();
-        LocalChatBot bot = new LocalChatBot(new OpenAIService(config));
+        LocalChatBot bot = new LocalChatBot(config);
         bot.start();
     }
 

--- a/src/test/java/com/example/streambot/TestUtils.java
+++ b/src/test/java/com/example/streambot/TestUtils.java
@@ -1,0 +1,30 @@
+package com.example.streambot;
+
+import java.net.http.HttpRequest;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+
+class TestUtils {
+    static String publisherToString(HttpRequest.BodyPublisher publisher) {
+        StringBuilder sb = new StringBuilder();
+        CountDownLatch latch = new CountDownLatch(1);
+        publisher.subscribe(new Flow.Subscriber<ByteBuffer>() {
+            @Override public void onSubscribe(Flow.Subscription subscription) { subscription.request(Long.MAX_VALUE); }
+            @Override public void onNext(ByteBuffer item) {
+                byte[] b = new byte[item.remaining()];
+                item.get(b);
+                sb.append(new String(b, StandardCharsets.UTF_8));
+            }
+            @Override public void onError(Throwable throwable) { latch.countDown(); }
+            @Override public void onComplete() { latch.countDown(); }
+        });
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- use `Config` values for OpenAIService
- forward temperature/top_p/max_tokens in payload
- pass config through LocalChatBot and StreamBotApplication
- update tests and add helper for decoding request body

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684af073add8832cb0c114b3e8dc88f7