### PR TITLE
Add idle suggestion behavior

### DIFF
--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -1,6 +1,11 @@
 package com.example.streambot;
 
+import java.util.List;
 import java.util.Scanner;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +16,7 @@ import org.slf4j.LoggerFactory;
 public class LocalChatBot {
     private static final Logger logger = LoggerFactory.getLogger(LocalChatBot.class);
     private final OpenAIService aiService;
+    private final Config config;
 
     public LocalChatBot() {
         this(Config.load());
@@ -20,24 +26,48 @@ public class LocalChatBot {
      * Create a bot using the provided configuration.
      */
     public LocalChatBot(Config config) {
-        this(new OpenAIService(config));
+        this(new OpenAIService(config), config);
     }
 
     /**
      * Create a bot with the given service. Primarily used for testing.
      */
     public LocalChatBot(OpenAIService service) {
+        this(service, Config.load());
+    }
+
+    /**
+     * Create a bot with the given service and configuration. Primarily used for testing.
+     */
+    public LocalChatBot(OpenAIService service, Config config) {
         this.aiService = service;
+        this.config = config != null ? config : Config.load();
     }
 
     /**
      * Start a simple REPL that sends user input to OpenAI and prints the response.
      */
     public void start() {
+        long timeoutMillis = config.getSilenceTimeout() * 1000L;
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        AtomicLong lastInput = new AtomicLong(System.currentTimeMillis());
+        Runnable silenceCheck = () -> {
+            long now = System.currentTimeMillis();
+            if (now - lastInput.get() >= timeoutMillis) {
+                String prompt = buildSuggestionPrompt();
+                logger.debug("Silence detected. Sending prompt: {}", prompt);
+                String response = aiService.ask(prompt);
+                logger.debug("Received suggestion: {}", response);
+                System.out.println("AI: " + response);
+                lastInput.set(now);
+            }
+        };
+        scheduler.scheduleAtFixedRate(silenceCheck, timeoutMillis, timeoutMillis, TimeUnit.MILLISECONDS);
         try (Scanner scanner = new Scanner(System.in)) {
             logger.info("Local ChatBot started. Type 'exit' to quit.");
             while (scanner.hasNextLine()) {
                 String input = scanner.nextLine().trim();
+                lastInput.set(System.currentTimeMillis());
                 if (input.equalsIgnoreCase("exit") || input.equalsIgnoreCase("quit")) {
                     break;
                 }
@@ -50,8 +80,24 @@ public class LocalChatBot {
                 System.out.println("AI: " + response);
             }
         } finally {
+            scheduler.shutdownNow();
             aiService.close();
             logger.debug("ChatBot service closed");
         }
+    }
+
+    private String buildSuggestionPrompt() {
+        String style = config.getConversationStyle();
+        List<String> topics = config.getTopics();
+        StringBuilder sb = new StringBuilder("Suggest a");
+        if (style != null && !style.isBlank() && !"neutral".equalsIgnoreCase(style)) {
+            sb.append(' ').append(style);
+        }
+        sb.append(" conversation topic");
+        if (!topics.isEmpty()) {
+            sb.append(" about ").append(String.join(", ", topics));
+        }
+        sb.append('.');
+        return sb.toString();
     }
 }

--- a/src/test/java/com/example/streambot/LocalChatBotTest.java
+++ b/src/test/java/com/example/streambot/LocalChatBotTest.java
@@ -4,8 +4,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import java.util.List;
+
+import com.example.streambot.Config;
 
 // Use a dummy service to avoid hitting the real OpenAI API
 import com.example.streambot.DummyOpenAIService;
@@ -29,6 +34,38 @@ public class LocalChatBotTest {
 
         assertTrue(svc.closed, "service closed");
         assertEquals(List.of("hi"), svc.received);
+    }
+
+    @Test
+    public void suggestsTopicAfterSilence() throws Exception {
+        System.setProperty("SILENCE_TIMEOUT", "1");
+        System.setProperty("CONVERSATION_STYLE", "casual");
+        System.setProperty("PREFERRED_TOPICS", "science");
+        Config cfg = Config.load();
+        DummyOpenAIService svc = new DummyOpenAIService();
+        LocalChatBot bot = new LocalChatBot(svc, cfg);
+
+        PipedOutputStream pos = new PipedOutputStream();
+        PipedInputStream pis = new PipedInputStream(pos);
+        InputStream orig = System.in;
+        System.setIn(pis);
+        Thread t = new Thread(bot::start);
+        t.start();
+
+        try {
+            TimeUnit.MILLISECONDS.sleep(1200);
+            pos.write("exit\n".getBytes(StandardCharsets.UTF_8));
+            pos.flush();
+            t.join(2000);
+        } finally {
+            System.setIn(orig);
+            System.clearProperty("SILENCE_TIMEOUT");
+            System.clearProperty("CONVERSATION_STYLE");
+            System.clearProperty("PREFERRED_TOPICS");
+        }
+
+        assertTrue(svc.closed, "service closed");
+        assertEquals(List.of("Suggest a casual conversation topic about science."), svc.received);
     }
 
 }


### PR DESCRIPTION
## Summary
- make `LocalChatBot` hold a `Config`
- start a scheduled task that asks OpenAI for a new topic when idle
- include conversation style and preferred topics in suggestion prompt
- add unit test that verifies suggestion after inactivity

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684af1f361e0832ca53cc3ad70af6eac