### PR TITLE
Enable TTS via OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StreamBot
 
-Aplicación Java basada en Maven que utiliza la API de OpenAI para generar respuestas y mostrarlas en la consola.
+Aplicación Java basada en Maven que utiliza la API de OpenAI para generar respuestas y mostrarlas en la consola. Opcionalmente puede reproducir la respuesta con voz sintética utilizando el servicio de Text-to-Speech de OpenAI.
 
 ## Requisitos previos
 
@@ -104,6 +104,8 @@ Las principales variables de configuración son:
 - `CONVERSATION_STYLE`: tono para las sugerencias de conversación.
 - `PREFERRED_TOPICS`: lista de temas preferidos separados por comas.
 - `SILENCE_TIMEOUT`: segundos de espera antes de proponer un nuevo tema.
+- `TTS_ENABLED`: si se establece en `true` reproduce las respuestas con voz sintética.
+- `TTS_VOICE`: voz a utilizar para la síntesis (`alloy`, `echo`, `fable`, `onyx`, `nova` o `shimmer`).
 
 Usa `env.example` como guía para crear tu propio `.env`:
 
@@ -117,6 +119,8 @@ OPENAI_MAX_TOKENS=
 CONVERSATION_STYLE=
 PREFERRED_TOPICS=
 SILENCE_TIMEOUT=
+TTS_ENABLED=
+TTS_VOICE=
 ```
 
 ## Licencia

--- a/env.example
+++ b/env.example
@@ -13,3 +13,7 @@ CONVERSATION_STYLE=
 PREFERRED_TOPICS=
 # Seconds of silence before a suggestion
 SILENCE_TIMEOUT=
+# Enable Text-to-Speech playback
+TTS_ENABLED=
+# Voice name for TTS (alloy, echo, fable, onyx, nova or shimmer)
+TTS_VOICE=

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <version>2.17.1</version>
         </dependency>
         <dependency>
+            <groupId>com.googlecode.soundlibs</groupId>
+            <artifactId>jlayer</artifactId>
+            <version>1.0.1-1</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.2</version>

--- a/src/main/java/com/example/streambot/Config.java
+++ b/src/main/java/com/example/streambot/Config.java
@@ -14,9 +14,12 @@ public class Config {
     private final List<String> topics;
     private final String conversationStyle;
     private final int silenceTimeout;
+    private final boolean ttsEnabled;
+    private final String ttsVoice;
 
     private Config(String model, double temperature, double topP, int maxTokens,
-                    List<String> topics, String conversationStyle, int silenceTimeout) {
+                    List<String> topics, String conversationStyle,
+                    int silenceTimeout, boolean ttsEnabled, String ttsVoice) {
         this.model = model;
         this.temperature = temperature;
         this.topP = topP;
@@ -24,6 +27,8 @@ public class Config {
         this.topics = List.copyOf(topics);
         this.conversationStyle = conversationStyle;
         this.silenceTimeout = silenceTimeout;
+        this.ttsEnabled = ttsEnabled;
+        this.ttsVoice = ttsVoice;
     }
 
     public String getModel() {
@@ -54,6 +59,14 @@ public class Config {
         return silenceTimeout;
     }
 
+    public boolean isTtsEnabled() {
+        return ttsEnabled;
+    }
+
+    public String getTtsVoice() {
+        return ttsVoice;
+    }
+
     /**
      * Load configuration values from system properties or a .env file.
      * Defaults are used when a property is not present or cannot be parsed.
@@ -65,6 +78,8 @@ public class Config {
         int maxTokens = parseInt(EnvUtils.get("OPENAI_MAX_TOKENS"), 2048);
         String style = EnvUtils.get("CONVERSATION_STYLE", "neutral");
         int timeout = parseInt(EnvUtils.get("SILENCE_TIMEOUT"), 30);
+        boolean ttsEnabled = Boolean.parseBoolean(EnvUtils.get("TTS_ENABLED", "false"));
+        String ttsVoice = EnvUtils.get("TTS_VOICE", "alloy");
         String topicsProp = EnvUtils.get("PREFERRED_TOPICS", "");
         List<String> topics = new ArrayList<>();
         if (topicsProp != null && !topicsProp.isBlank()) {
@@ -75,7 +90,8 @@ public class Config {
                 }
             }
         }
-        return new Config(model, temperature, topP, maxTokens, topics, style, timeout);
+        return new Config(model, temperature, topP, maxTokens,
+                topics, style, timeout, ttsEnabled, ttsVoice);
     }
 
     private static double parseDouble(String val, double def) {

--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -6,8 +6,11 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.example.streambot.SpeechService;
 
 /**
  * A simple console-based chatbot that interacts with the OpenAI API
@@ -17,6 +20,7 @@ public class LocalChatBot {
     private static final Logger logger = LoggerFactory.getLogger(LocalChatBot.class);
     private final OpenAIService aiService;
     private final Config config;
+    private final SpeechService speechService;
 
     public LocalChatBot() {
         this(Config.load());
@@ -42,6 +46,7 @@ public class LocalChatBot {
     public LocalChatBot(OpenAIService service, Config config) {
         this.aiService = service;
         this.config = config != null ? config : Config.load();
+        this.speechService = new SpeechService(this.config);
     }
 
     /**
@@ -59,6 +64,7 @@ public class LocalChatBot {
                 String response = aiService.ask(prompt);
                 logger.debug("Received suggestion: {}", response);
                 System.out.println("AI: " + response);
+                speechService.speak(response);
                 lastInput.set(now);
             }
         };
@@ -78,6 +84,7 @@ public class LocalChatBot {
                 String response = aiService.ask(input);
                 logger.debug("Received response: {}", response);
                 System.out.println("AI: " + response);
+                speechService.speak(response);
             }
         } finally {
             scheduler.shutdownNow();

--- a/src/main/java/com/example/streambot/SpeechService.java
+++ b/src/main/java/com/example/streambot/SpeechService.java
@@ -1,0 +1,67 @@
+package com.example.streambot;
+
+import javazoom.jl.player.Player;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Service to convert text to speech using OpenAI's TTS endpoint.
+ */
+public class SpeechService {
+    private static final Logger logger = LoggerFactory.getLogger(SpeechService.class);
+    private final HttpClient client;
+    private final String apiKey;
+    private final String voice;
+    private final boolean enabled;
+
+    /** Create using the default HttpClient and configuration. */
+    public SpeechService(Config config) {
+        this(HttpClient.newHttpClient(), config);
+    }
+
+    SpeechService(HttpClient client, Config config) {
+        this.client = client;
+        this.apiKey = EnvUtils.get("OPENAI_API_KEY");
+        this.voice = config.getTtsVoice();
+        this.enabled = config.isTtsEnabled() && apiKey != null && !apiKey.isBlank();
+    }
+
+    /**
+     * Speak the provided text if TTS is enabled.
+     */
+    public void speak(String text) {
+        if (!enabled) {
+            logger.debug("TTS disabled or API key missing");
+            return;
+        }
+        try {
+            String payload = String.format("{\"model\":\"tts-1\",\"input\":%s,\"voice\":\"%s\"}",
+                    toJsonString(text), voice);
+            HttpRequest req = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.openai.com/v1/audio/speech"))
+                    .header("Authorization", "Bearer " + apiKey)
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                    .build();
+            HttpResponse<byte[]> resp = client.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            byte[] audio = resp.body();
+            try (ByteArrayInputStream bis = new ByteArrayInputStream(audio)) {
+                Player player = new Player(bis);
+                player.play();
+            }
+        } catch (Exception e) {
+            logger.error("Error performing TTS", e);
+        }
+    }
+
+    private static String toJsonString(String s) {
+        return '"' + s.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+}

--- a/src/test/java/com/example/streambot/ConfigTest.java
+++ b/src/test/java/com/example/streambot/ConfigTest.java
@@ -18,6 +18,8 @@ public class ConfigTest {
         System.clearProperty("CONVERSATION_STYLE");
         System.clearProperty("PREFERRED_TOPICS");
         System.clearProperty("SILENCE_TIMEOUT");
+        System.clearProperty("TTS_ENABLED");
+        System.clearProperty("TTS_VOICE");
     }
 
     @Test
@@ -29,6 +31,8 @@ public class ConfigTest {
         System.setProperty("CONVERSATION_STYLE", "formal");
         System.setProperty("PREFERRED_TOPICS", "one, two ,three");
         System.setProperty("SILENCE_TIMEOUT", "15");
+        System.setProperty("TTS_ENABLED", "true");
+        System.setProperty("TTS_VOICE", "onyx");
 
         Config cfg = Config.load();
         assertEquals("gpt-test", cfg.getModel());
@@ -38,6 +42,8 @@ public class ConfigTest {
         assertEquals(List.of("one", "two", "three"), cfg.getTopics());
         assertEquals("formal", cfg.getConversationStyle());
         assertEquals(15, cfg.getSilenceTimeout());
+        assertTrue(cfg.isTtsEnabled());
+        assertEquals("onyx", cfg.getTtsVoice());
     }
 
     @Test
@@ -50,5 +56,7 @@ public class ConfigTest {
         assertTrue(cfg.getTopics().isEmpty());
         assertEquals("neutral", cfg.getConversationStyle());
         assertEquals(30, cfg.getSilenceTimeout());
+        assertFalse(cfg.isTtsEnabled());
+        assertEquals("alloy", cfg.getTtsVoice());
     }
 }


### PR DESCRIPTION
## Summary
- add TTS fields in `Config`
- document new variables in README and env.example
- add new `SpeechService` that calls OpenAI's `/v1/audio/speech`
- speak replies and suggestions in `LocalChatBot`
- include jlayer dependency
- update tests for new config fields

## Testing
- `mvn -DskipTests install`
- `mvn test`


------
https://chatgpt.com/codex/tasks/task_e_684af5a76254832cb7527cce7af6c666