### PR TITLE
Add TTS setup options

### DIFF
--- a/src/main/java/com/example/streambot/SetupWizard.java
+++ b/src/main/java/com/example/streambot/SetupWizard.java
@@ -60,6 +60,12 @@ public class SetupWizard {
             System.out.print("SILENCE_TIMEOUT: ");
             String timeout = scanner.nextLine().trim();
 
+            System.out.print("TTS_ENABLED: ");
+            String ttsEnabled = scanner.nextLine().trim();
+
+            System.out.print("TTS_VOICE: ");
+            String ttsVoice = scanner.nextLine().trim();
+
             try (PrintWriter out = new PrintWriter(new FileWriter(env))) {
                 out.println("OPENAI_API_KEY=" + key);
                 out.println("OPENAI_MODEL=" + model);
@@ -69,6 +75,8 @@ public class SetupWizard {
                 out.println("CONVERSATION_STYLE=" + style);
                 out.println("PREFERRED_TOPICS=" + topics);
                 out.println("SILENCE_TIMEOUT=" + timeout);
+                out.println("TTS_ENABLED=" + ttsEnabled);
+                out.println("TTS_VOICE=" + ttsVoice);
             }
 
             System.setProperty("OPENAI_API_KEY", key);
@@ -79,6 +87,8 @@ public class SetupWizard {
             System.setProperty("CONVERSATION_STYLE", style);
             System.setProperty("PREFERRED_TOPICS", topics);
             System.setProperty("SILENCE_TIMEOUT", timeout);
+            System.setProperty("TTS_ENABLED", ttsEnabled);
+            System.setProperty("TTS_VOICE", ttsVoice);
 
             System.out.println("Archivo .env creado.\n");
             logger.info(".env file created");

--- a/src/test/java/com/example/streambot/SetupWizardTest.java
+++ b/src/test/java/com/example/streambot/SetupWizardTest.java
@@ -33,6 +33,8 @@ public class SetupWizardTest {
                     "casual",
                     "science,tech",
                     "30",
+                    "true",
+                    "nova",
                     "");
             System.setIn(new ByteArrayInputStream(userInput.getBytes(StandardCharsets.UTF_8)));
             SetupWizard.run();
@@ -44,6 +46,8 @@ public class SetupWizardTest {
             assertEquals("casual", System.getProperty("CONVERSATION_STYLE"));
             assertEquals("science,tech", System.getProperty("PREFERRED_TOPICS"));
             assertEquals("30", System.getProperty("SILENCE_TIMEOUT"));
+            assertEquals("true", System.getProperty("TTS_ENABLED"));
+            assertEquals("nova", System.getProperty("TTS_VOICE"));
             assertTrue(Files.exists(env), ".env should be created");
             String content = Files.readString(env);
             String expected = String.join("\n",
@@ -55,6 +59,8 @@ public class SetupWizardTest {
                     "CONVERSATION_STYLE=casual",
                     "PREFERRED_TOPICS=science,tech",
                     "SILENCE_TIMEOUT=30",
+                    "TTS_ENABLED=true",
+                    "TTS_VOICE=nova",
                     "");
             assertEquals(expected, content);
         } finally {
@@ -67,6 +73,8 @@ public class SetupWizardTest {
             System.clearProperty("CONVERSATION_STYLE");
             System.clearProperty("PREFERRED_TOPICS");
             System.clearProperty("SILENCE_TIMEOUT");
+            System.clearProperty("TTS_ENABLED");
+            System.clearProperty("TTS_VOICE");
             Files.deleteIfExists(env);
             if (existed) {
                 Files.move(backup, env);
@@ -97,6 +105,8 @@ public class SetupWizardTest {
             System.clearProperty("CONVERSATION_STYLE");
             System.clearProperty("PREFERRED_TOPICS");
             System.clearProperty("SILENCE_TIMEOUT");
+            System.clearProperty("TTS_ENABLED");
+            System.clearProperty("TTS_VOICE");
             Files.deleteIfExists(env);
             if (existed) {
                 Files.move(backup, env);

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -72,6 +72,8 @@ public class StreamBotApplicationTest {
                     "casual",
                     "science,tech",
                     "30",
+                    "true",
+                    "nova",
                     "exit",
                     "");
             System.setIn(new ByteArrayInputStream(userInput.getBytes(StandardCharsets.UTF_8)));
@@ -87,6 +89,8 @@ public class StreamBotApplicationTest {
                     "CONVERSATION_STYLE=casual",
                     "PREFERRED_TOPICS=science,tech",
                     "SILENCE_TIMEOUT=30",
+                    "TTS_ENABLED=true",
+                    "TTS_VOICE=nova",
                     "");
             assertEquals(expected, content);
         } finally {


### PR DESCRIPTION
## Summary
- prompt for TTS settings in `SetupWizard`
- persist TTS values in `.env` and system properties
- update tests to expect `TTS_ENABLED` and `TTS_VOICE`

## Testing
- `mvn test -DtrimStackTrace=false`

------
https://chatgpt.com/codex/tasks/task_e_684b1dd3493c832caea5484a29e20654