### PR TITLE
Add SpeechService unit tests

### DIFF
--- a/src/test/java/com/example/streambot/SpeechServiceTest.java
+++ b/src/test/java/com/example/streambot/SpeechServiceTest.java
@@ -1,0 +1,113 @@
+package com.example.streambot;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SpeechServiceTest {
+    private static class DummyResponse implements HttpResponse<byte[]> {
+        private final byte[] body;
+        DummyResponse(byte[] body) { this.body = body; }
+        @Override public int statusCode() { return 200; }
+        @Override public HttpRequest request() { return null; }
+        @Override public Optional<HttpResponse<byte[]>> previousResponse() { return Optional.empty(); }
+        @Override public HttpHeaders headers() { return HttpHeaders.of(Map.of(), (a,b) -> true); }
+        @Override public byte[] body() { return body; }
+        @Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+        @Override public URI uri() { return URI.create("https://api.openai.com"); }
+        @Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+    }
+
+    private static class StubHttpClient extends HttpClient {
+        private final HttpClient delegate = HttpClient.newHttpClient();
+        private final HttpResponse<byte[]> response;
+        private final IOException exception;
+        HttpRequest lastRequest;
+        String body;
+        StubHttpClient(HttpResponse<byte[]> response) {
+            this.response = response;
+            this.exception = null;
+        }
+        StubHttpClient(IOException ex) {
+            this.response = null;
+            this.exception = ex;
+        }
+        @Override public Optional<java.net.CookieHandler> cookieHandler() { return delegate.cookieHandler(); }
+        @Override public Optional<Duration> connectTimeout() { return delegate.connectTimeout(); }
+        @Override public Redirect followRedirects() { return delegate.followRedirects(); }
+        @Override public Optional<java.net.ProxySelector> proxy() { return delegate.proxy(); }
+        @Override public SSLContext sslContext() { return delegate.sslContext(); }
+        @Override public SSLParameters sslParameters() { return delegate.sslParameters(); }
+        @Override public Optional<java.net.Authenticator> authenticator() { return delegate.authenticator(); }
+        @Override public HttpClient.Version version() { return delegate.version(); }
+        @Override public Optional<Executor> executor() { return delegate.executor(); }
+        @Override
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler) throws IOException {
+            lastRequest = request;
+            body = request.bodyPublisher().map(TestUtils::publisherToString).orElse(null);
+            if (exception != null) {
+                throw exception;
+            }
+            return (HttpResponse<T>) response;
+        }
+        @Override public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> handler) { return CompletableFuture.completedFuture(null); }
+        @Override public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest request, HttpResponse.BodyHandler<T> handler, HttpResponse.PushPromiseHandler<T> h) { return CompletableFuture.completedFuture(null); }
+    }
+
+    @AfterEach
+    public void clearProps() {
+        System.clearProperty("OPENAI_API_KEY");
+        System.clearProperty("TTS_ENABLED");
+        System.clearProperty("TTS_VOICE");
+        javazoom.jl.player.Player.played = false;
+    }
+
+    @Test
+    public void speakSendsPayloadAndPlaysAudio() {
+        System.setProperty("OPENAI_API_KEY", "key");
+        System.setProperty("TTS_ENABLED", "true");
+        System.setProperty("TTS_VOICE", "nova");
+        Config cfg = Config.load();
+        byte[] data = {1,2,3};
+        DummyResponse resp = new DummyResponse(data);
+        StubHttpClient client = new StubHttpClient(resp);
+        SpeechService svc = new SpeechService(client, cfg);
+
+        svc.speak("hi");
+
+        assertTrue(javazoom.jl.player.Player.played, "playback should occur");
+        assertNotNull(client.lastRequest, "request sent");
+        assertTrue(client.body.contains("\"model\":\"tts-1\""));
+        assertTrue(client.body.contains("\"input\":\"hi\""));
+        assertTrue(client.body.contains("\"voice\":\"nova\""));
+    }
+
+    @Test
+    public void speakHandlesErrors() {
+        System.setProperty("OPENAI_API_KEY", "key");
+        System.setProperty("TTS_ENABLED", "true");
+        Config cfg = Config.load();
+        StubHttpClient client = new StubHttpClient(new IOException("boom"));
+        SpeechService svc = new SpeechService(client, cfg);
+
+        assertDoesNotThrow(() -> svc.speak("hello"));
+        assertFalse(javazoom.jl.player.Player.played, "play should not be called");
+    }
+}

--- a/src/test/java/javazoom/jl/player/Player.java
+++ b/src/test/java/javazoom/jl/player/Player.java
@@ -1,0 +1,15 @@
+package javazoom.jl.player;
+
+import java.io.InputStream;
+
+/** Simple stub for JLayer Player used in tests. */
+public class Player {
+    public static boolean played = false;
+    public final InputStream in;
+    public Player(InputStream in) {
+        this.in = in;
+    }
+    public void play() {
+        played = true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a stub `Player` class under the same package used by `SpeechService`
- create `SpeechServiceTest` using a mocked `HttpClient`
- verify correct payload, playback invocation and error handling

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684b1f023664832c86f3338a3e2c7158