### PR TITLE
Add TTS CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Al compilar con Maven se generar\u00e1 el archivo `target/streambot-1.0-SNAPSHOT
 mvn package
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
-Antes de ejecutar asegúrate de que las variables `OPENAI_API_KEY` y `OPENAI_MODEL` estén disponibles en tu entorno o definidas en `.env`. También puedes pasarlas al iniciar la aplicación con los argumentos `--api-key` y `--model`. De forma predeterminada se usa `gpt-3.5-turbo` como modelo.
+Antes de ejecutar asegúrate de que las variables `OPENAI_API_KEY` y `OPENAI_MODEL` estén disponibles en tu entorno o definidas en `.env`. También puedes pasarlas al iniciar la aplicación con los argumentos `--api-key` y `--model`. De forma predeterminada se usa `gpt-3.5-turbo` como modelo. Además es posible habilitar la síntesis de voz con `--tts-enabled true` y seleccionar la voz mediante `--tts-voice`.
 
 ## Ejecutar pruebas
 Para correr las pruebas unitarias con Maven utilice:
@@ -92,7 +92,7 @@ java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 
 
 ## Configuración de la API de OpenAI
-Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL` (por ejemplo `gpt-4`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard`, un asistente interactivo que solicitará los valores y generará el archivo automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes usar `env.example` como plantilla.
+Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL` (por ejemplo `gpt-4`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard`, un asistente interactivo que solicitará los valores y generará el archivo automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes habilitar la síntesis con `--tts-enabled` y elegir la voz con `--tts-voice`. Puedes usar `env.example` como plantilla.
 
 Las principales variables de configuración son:
 

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -42,6 +42,12 @@ public class StreamBotApplication {
             } else if ("--model".equals(args[i]) && i + 1 < args.length) {
                 map.put("OPENAI_MODEL", args[++i]);
                 logger.debug("Parsed model from CLI: {}", map.get("OPENAI_MODEL"));
+            } else if ("--tts-enabled".equals(args[i]) && i + 1 < args.length) {
+                map.put("TTS_ENABLED", args[++i]);
+                logger.debug("Parsed TTS_ENABLED from CLI: {}", map.get("TTS_ENABLED"));
+            } else if ("--tts-voice".equals(args[i]) && i + 1 < args.length) {
+                map.put("TTS_VOICE", args[++i]);
+                logger.debug("Parsed TTS_VOICE from CLI: {}", map.get("TTS_VOICE"));
             }
         }
         return map;

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -28,6 +28,18 @@ public class StreamBotApplicationTest {
     }
 
     @Test
+    public void parsesTtsEnabledFlag() {
+        Map<String, String> result = StreamBotApplication.parseArgs(new String[]{"--tts-enabled", "true"});
+        assertEquals("true", result.get("TTS_ENABLED"));
+    }
+
+    @Test
+    public void parsesTtsVoiceFlag() {
+        Map<String, String> result = StreamBotApplication.parseArgs(new String[]{"--tts-voice", "nova"});
+        assertEquals("nova", result.get("TTS_VOICE"));
+    }
+
+    @Test
     public void mainSkipsWizardIfApiKeyProvided(@TempDir Path tmp) throws Exception {
         Path env = Path.of(".env");
         Path backup = tmp.resolve("env.bak");


### PR DESCRIPTION
## Summary
- extend `parseArgs()` to accept `--tts-enabled` and `--tts-voice`
- document new flags in README
- test new CLI arguments

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684b2066dfbc832c8b43732a0693737f