### PR TITLE
Add supported model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 
 
 ## Configuración de la API de OpenAI
-Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL` (por ejemplo `gpt-4`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard`, un asistente interactivo que solicitará los valores y generará el archivo automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes habilitar la síntesis con `--tts-enabled` y elegir la voz con `--tts-voice`. Usa `--setup` si deseas volver a ejecutar el asistente y sobrescribir la configuración actual. Puedes usar `env.example` como plantilla.
+Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL`. Los modelos soportados son `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` y `gpt-4-32k` (estos valores se mostrarán cuando `SetupWizard` pregunte por `OPENAI_MODEL`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard`, un asistente interactivo que solicitará los valores y generará el archivo automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes habilitar la síntesis con `--tts-enabled` y elegir la voz con `--tts-voice`. Usa `--setup` si deseas volver a ejecutar el asistente y sobrescribir la configuración actual. Puedes usar `env.example` como plantilla.
 
 Las principales variables de configuración son:
 
 - `OPENAI_API_KEY`: clave de autenticación para la API de OpenAI.
-- `OPENAI_MODEL`: modelo a utilizar.
+- `OPENAI_MODEL`: modelo a utilizar. Los valores admitidos son `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` y `gpt-4-32k`.
 - `OPENAI_TEMPERATURE`: grado de aleatoriedad (0–2).
 - `OPENAI_TOP_P`: umbral de muestreo *top p*.
 - `OPENAI_MAX_TOKENS`: límite de tokens por respuesta.

--- a/src/main/java/com/example/streambot/SetupWizard.java
+++ b/src/main/java/com/example/streambot/SetupWizard.java
@@ -5,6 +5,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Scanner;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +18,12 @@ import com.example.streambot.EnvUtils;
  */
 public class SetupWizard {
     private static final Logger logger = LoggerFactory.getLogger(SetupWizard.class);
+    /** List of models that the application supports. */
+    public static final List<String> SUPPORTED_MODELS = List.of(
+            "gpt-3.5-turbo",
+            "gpt-3.5-turbo-16k",
+            "gpt-4",
+            "gpt-4-32k");
     /**
      * Run the wizard to create or update the {@code .env} file.
      * Existing values are overwritten and system properties are updated.
@@ -30,7 +37,7 @@ public class SetupWizard {
             System.out.print("OPENAI_API_KEY: ");
             String key = scanner.nextLine().trim();
 
-            System.out.print("OPENAI_MODEL: ");
+            System.out.print("OPENAI_MODEL " + SUPPORTED_MODELS + ": ");
             String model = scanner.nextLine().trim();
 
             System.out.print("OPENAI_TEMPERATURE: ");


### PR DESCRIPTION
## Summary
- list supported OpenAI models in `SetupWizard`
- display the available models when prompting for `OPENAI_MODEL`
- document supported models in README

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684b251a850c832c9dbb4be37caac33d