### PR TITLE
Fix newline escaping in TTS payload

### DIFF
--- a/src/main/java/com/example/streambot/SpeechService.java
+++ b/src/main/java/com/example/streambot/SpeechService.java
@@ -7,6 +7,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +17,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SpeechService {
     private static final Logger logger = LoggerFactory.getLogger(SpeechService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     private final HttpClient client;
     private final String apiKey;
     private final String voice;
@@ -62,6 +64,11 @@ public class SpeechService {
     }
 
     private static String toJsonString(String s) {
-        return '"' + s.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+        try {
+            return MAPPER.writeValueAsString(s);
+        } catch (Exception e) {
+            logger.error("Error serializing JSON", e);
+            return "\"\"";
+        }
     }
 }

--- a/src/test/java/com/example/streambot/SpeechServiceTest.java
+++ b/src/test/java/com/example/streambot/SpeechServiceTest.java
@@ -100,6 +100,25 @@ public class SpeechServiceTest {
     }
 
     @Test
+    public void speakEncodesNewlines() throws Exception {
+        System.setProperty("OPENAI_API_KEY", "key");
+        System.setProperty("TTS_ENABLED", "true");
+        System.setProperty("TTS_VOICE", "nova");
+        Config cfg = Config.load();
+        DummyResponse resp = new DummyResponse(new byte[0]);
+        StubHttpClient client = new StubHttpClient(resp);
+        SpeechService svc = new SpeechService(client, cfg);
+
+        svc.speak("hello\nworld");
+
+        assertNotNull(client.body, "payload sent");
+        Map<?, ?> map = new com.fasterxml.jackson.databind.ObjectMapper().readValue(client.body, Map.class);
+        assertEquals("hello\nworld", map.get("input"));
+        assertEquals("tts-1", map.get("model"));
+        assertEquals("nova", map.get("voice"));
+    }
+
+    @Test
     public void speakHandlesErrors() {
         System.setProperty("OPENAI_API_KEY", "key");
         System.setProperty("TTS_ENABLED", "true");


### PR DESCRIPTION
## Summary
- escape control characters in `SpeechService.toJsonString` using Jackson
- validate newline encoding in `SpeechServiceTest`

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684b2e50bde4832cb1af28cd4671ee35