### PR TITLE
Validate model input in SetupWizard

### DIFF
--- a/src/main/java/com/example/streambot/SetupWizard.java
+++ b/src/main/java/com/example/streambot/SetupWizard.java
@@ -39,6 +39,12 @@ public class SetupWizard {
 
             System.out.print("OPENAI_MODEL " + SUPPORTED_MODELS + ": ");
             String model = scanner.nextLine().trim();
+            if (!SUPPORTED_MODELS.contains(model)) {
+                String def = SUPPORTED_MODELS.get(0);
+                System.out.println("Modelo no válido, se usará " + def);
+                logger.warn("Unsupported model '{}', defaulting to {}", model, def);
+                model = def;
+            }
 
             System.out.print("OPENAI_TEMPERATURE: ");
             String temp = scanner.nextLine().trim();

--- a/src/test/java/com/example/streambot/SetupWizardTest.java
+++ b/src/test/java/com/example/streambot/SetupWizardTest.java
@@ -26,7 +26,7 @@ public class SetupWizardTest {
         try {
             String userInput = String.join("\n",
                     "bar",
-                    "model",
+                    "gpt-4",
                     "0.7",
                     "0.9",
                     "2048",
@@ -39,7 +39,7 @@ public class SetupWizardTest {
             System.setIn(new ByteArrayInputStream(userInput.getBytes(StandardCharsets.UTF_8)));
             SetupWizard.run();
             assertEquals("bar", System.getProperty("OPENAI_API_KEY"));
-            assertEquals("model", System.getProperty("OPENAI_MODEL"));
+            assertEquals("gpt-4", System.getProperty("OPENAI_MODEL"));
             assertEquals("0.7", System.getProperty("OPENAI_TEMPERATURE"));
             assertEquals("0.9", System.getProperty("OPENAI_TOP_P"));
             assertEquals("2048", System.getProperty("OPENAI_MAX_TOKENS"));
@@ -52,7 +52,7 @@ public class SetupWizardTest {
             String content = Files.readString(env);
             String expected = String.join("\n",
                     "OPENAI_API_KEY=bar",
-                    "OPENAI_MODEL=model",
+                    "OPENAI_MODEL=gpt-4",
                     "OPENAI_TEMPERATURE=0.7",
                     "OPENAI_TOP_P=0.9",
                     "OPENAI_MAX_TOKENS=2048",
@@ -97,7 +97,7 @@ public class SetupWizardTest {
         InputStream originalIn = System.in;
         try {
             String userInput = String.join("\n",
-                    "new", "model", "0.5", "0.9", "100", "formal",
+                    "new", "gpt-3.5-turbo", "0.5", "0.9", "100", "formal",
                     "science", "10", "false", "alloy", "");
             System.setIn(new ByteArrayInputStream(userInput.getBytes(StandardCharsets.UTF_8)));
             SetupWizard.run();
@@ -105,6 +105,46 @@ public class SetupWizardTest {
             assertTrue(Files.exists(env), ".env should exist");
             String firstLine = Files.readAllLines(env).get(0);
             assertEquals("OPENAI_API_KEY=new", firstLine);
+        } finally {
+            System.setIn(originalIn);
+            System.clearProperty("OPENAI_API_KEY");
+            System.clearProperty("OPENAI_MODEL");
+            System.clearProperty("OPENAI_TEMPERATURE");
+            System.clearProperty("OPENAI_TOP_P");
+            System.clearProperty("OPENAI_MAX_TOKENS");
+            System.clearProperty("CONVERSATION_STYLE");
+            System.clearProperty("PREFERRED_TOPICS");
+            System.clearProperty("SILENCE_TIMEOUT");
+            System.clearProperty("TTS_ENABLED");
+            System.clearProperty("TTS_VOICE");
+            Files.deleteIfExists(env);
+            if (existed) {
+                Files.move(backup, env);
+            } else {
+                Files.deleteIfExists(backup);
+            }
+        }
+    }
+
+    @Test
+    public void runDefaultsInvalidModel(@TempDir Path tmp) throws Exception {
+        Path env = Path.of(".env");
+        Path backup = tmp.resolve("env.bak");
+        boolean existed = Files.exists(env);
+        if (existed) {
+            Files.move(env, backup);
+        }
+        InputStream originalIn = System.in;
+        try {
+            String userInput = String.join("\n",
+                    "baz", "bad-model", "0.7", "0.9", "100", "formal",
+                    "", "10", "false", "alloy", "");
+            System.setIn(new ByteArrayInputStream(userInput.getBytes(StandardCharsets.UTF_8)));
+            SetupWizard.run();
+            assertEquals(SetupWizard.SUPPORTED_MODELS.get(0), System.getProperty("OPENAI_MODEL"));
+            assertTrue(Files.exists(env), ".env should exist");
+            String line = Files.readAllLines(env).get(1);
+            assertEquals("OPENAI_MODEL=" + SetupWizard.SUPPORTED_MODELS.get(0), line);
         } finally {
             System.setIn(originalIn);
             System.clearProperty("OPENAI_API_KEY");

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -83,7 +83,7 @@ public class StreamBotApplicationTest {
         try {
             String userInput = String.join("\n",
                     "bar",
-                    "model",
+                    "gpt-4",
                     "0.7",
                     "0.9",
                     "2048",
@@ -100,7 +100,7 @@ public class StreamBotApplicationTest {
             String content = Files.readString(env);
             String expected = String.join("\n",
                     "OPENAI_API_KEY=bar",
-                    "OPENAI_MODEL=model",
+                    "OPENAI_MODEL=gpt-4",
                     "OPENAI_TEMPERATURE=0.7",
                     "OPENAI_TOP_P=0.9",
                     "OPENAI_MAX_TOKENS=2048",
@@ -134,7 +134,7 @@ public class StreamBotApplicationTest {
         try {
             String userInput = String.join("\n",
                     "baz",
-                    "model",
+                    "gpt-3.5-turbo",
                     "0.7",
                     "0.9",
                     "2048",


### PR DESCRIPTION
## Summary
- validate `OPENAI_MODEL` input in SetupWizard against supported models
- adjust tests to use valid model values
- add test for invalid model falling back to default

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684b2f7c2d28832cbbe65b1e1fb5de7c