### PR TITLE
Fix interrupt handling in OpenAIService

### DIFF
--- a/src/main/java/com/example/streambot/OpenAIService.java
+++ b/src/main/java/com/example/streambot/OpenAIService.java
@@ -103,8 +103,11 @@ public class OpenAIService {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
             logger.debug("Received response with status {}", response.statusCode());
             return parseContent(response.body());
-        } catch (InterruptedException | IOException e) {
+        } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            logger.error("Error communicating with OpenAI", e);
+            return "";
+        } catch (IOException e) {
             logger.error("Error communicating with OpenAI", e);
             return "";
         }

--- a/src/test/java/com/example/streambot/OpenAIServiceTest.java
+++ b/src/test/java/com/example/streambot/OpenAIServiceTest.java
@@ -112,6 +112,16 @@ public class OpenAIServiceTest {
     }
 
     @Test
+    public void threadNotInterruptedOnIOException() {
+        System.setProperty("OPENAI_API_KEY", "key");
+        Config cfg = Config.load();
+        OpenAIService svc = new OpenAIService(new StubHttpClient(new IOException("fail")), cfg);
+        assertFalse(Thread.currentThread().isInterrupted());
+        svc.ask("hi");
+        assertFalse(Thread.currentThread().isInterrupted());
+    }
+
+    @Test
     public void usesModelFromEnv() throws Exception {
         System.setProperty("OPENAI_API_KEY", "key");
         System.setProperty("OPENAI_MODEL", "gpt-test");


### PR DESCRIPTION
## Summary
- handle InterruptedException and IOException separately
- ensure IOException does not set the interrupt flag
- test thread interrupt flag remains clear on IOException

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684b3fa390c8832c9967ef1b89dec778