### PR TITLE
Fix SpeechService JSON handling

### DIFF
--- a/src/main/java/com/example/streambot/SpeechService.java
+++ b/src/main/java/com/example/streambot/SpeechService.java
@@ -44,8 +44,11 @@ public class SpeechService {
             return;
         }
         try {
-            String payload = String.format("{\"model\":\"tts-1\",\"input\":%s,\"voice\":\"%s\"}",
-                    toJsonString(text), voice);
+            java.util.Map<String, Object> map = java.util.Map.of(
+                    "model", "tts-1",
+                    "input", text,
+                    "voice", voice);
+            String payload = MAPPER.writeValueAsString(map);
             HttpRequest req = HttpRequest.newBuilder()
                     .uri(URI.create("https://api.openai.com/v1/audio/speech"))
                     .header("Authorization", "Bearer " + apiKey)
@@ -63,12 +66,4 @@ public class SpeechService {
         }
     }
 
-    private static String toJsonString(String s) {
-        try {
-            return MAPPER.writeValueAsString(s);
-        } catch (Exception e) {
-            logger.error("Error serializing JSON", e);
-            return "\"\"";
-        }
-    }
 }

--- a/src/test/java/com/example/streambot/SpeechServiceTest.java
+++ b/src/test/java/com/example/streambot/SpeechServiceTest.java
@@ -94,9 +94,11 @@ public class SpeechServiceTest {
 
         assertTrue(javazoom.jl.player.Player.played, "playback should occur");
         assertNotNull(client.lastRequest, "request sent");
-        assertTrue(client.body.contains("\"model\":\"tts-1\""));
-        assertTrue(client.body.contains("\"input\":\"hi\""));
-        assertTrue(client.body.contains("\"voice\":\"nova\""));
+        Map<?, ?> payload = new com.fasterxml.jackson.databind.ObjectMapper()
+                .readValue(client.body, Map.class);
+        assertEquals("tts-1", payload.get("model"));
+        assertEquals("hi", payload.get("input"));
+        assertEquals("nova", payload.get("voice"));
     }
 
     @Test

--- a/src/test/java/com/example/streambot/SpeechServiceTest.java
+++ b/src/test/java/com/example/streambot/SpeechServiceTest.java
@@ -80,7 +80,7 @@ public class SpeechServiceTest {
     }
 
     @Test
-    public void speakSendsPayloadAndPlaysAudio() {
+    public void speakSendsPayloadAndPlaysAudio() throws Exception {
         System.setProperty("OPENAI_API_KEY", "key");
         System.setProperty("TTS_ENABLED", "true");
         System.setProperty("TTS_VOICE", "nova");


### PR DESCRIPTION
## Summary
- construct TTS payload using a `Map` and serialize with `ObjectMapper`
- update SpeechService unit tests to parse JSON payload

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b40e7d838832caf67577cc7c2b8aa