### PR TITLE
Add --help option with usage info

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -63,7 +63,7 @@ When compiling with Maven the file `target/streambot-1.0-SNAPSHOT-shaded.jar` wi
 ./mvnw package
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
-Before running make sure the variables `OPENAI_API_KEY` and `OPENAI_MODEL` are present in your environment or defined in `.env`. They can also be provided as arguments `--api-key` and `--model`. By default the model `gpt-3.5-turbo` is used. You can enable speech synthesis with `--tts-enabled true` and choose the voice using `--tts-voice`.
+Before running make sure the variables `OPENAI_API_KEY` and `OPENAI_MODEL` are present in your environment or defined in `.env`. They can also be provided as arguments `--api-key` and `--model`. By default the model `gpt-3.5-turbo` is used. You can enable speech synthesis with `--tts-enabled true` and choose the voice using `--tts-voice`. Use `--help` to list all options.
 
 ## Configuration
 Sign up at [OpenAI](https://platform.openai.com/) and create a new *API key*. Copy it to the `.env` file as the value for `OPENAI_API_KEY`. You can indicate the model with `OPENAI_MODEL`. Supported models are `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` and `gpt-4-32k`. If `.env` does not exist, running the application will launch `SetupWizard`, an interactive assistant that requests the values and generates the file automatically. You can also provide these values using `--api-key` and `--model`. Speech can be enabled with `--tts-enabled` and the voice chosen with `--tts-voice`. Use `--setup` if you want to run the wizard again and overwrite the current configuration. The file `env.example` can be used as a template.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Al compilar con Maven se generar\u00e1 el archivo `target/streambot-1.0-SNAPSHOT
 ./mvnw package
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
-Antes de ejecutar asegúrate de que las variables `OPENAI_API_KEY` y `OPENAI_MODEL` estén disponibles en tu entorno o definidas en `.env`. También puedes pasarlas al iniciar la aplicación con los argumentos `--api-key` y `--model`. De forma predeterminada se usa `gpt-3.5-turbo` como modelo. Además es posible habilitar la síntesis de voz con `--tts-enabled true` y seleccionar la voz mediante `--tts-voice`.
+Antes de ejecutar asegúrate de que las variables `OPENAI_API_KEY` y `OPENAI_MODEL` estén disponibles en tu entorno o definidas en `.env`. También puedes pasarlas al iniciar la aplicación con los argumentos `--api-key` y `--model`. De forma predeterminada se usa `gpt-3.5-turbo` como modelo. Además es posible habilitar la síntesis de voz con `--tts-enabled true` y seleccionar la voz mediante `--tts-voice`. Usa `--help` para listar todas las opciones.
 
 ## Ejecutar pruebas
 Para correr las pruebas unitarias con Maven utilice:

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -20,6 +20,10 @@ public class StreamBotApplication {
         logger.info("Starting StreamBot");
         Map<String, String> cli = parseArgs(args);
         logger.debug("Parsed CLI arguments: {}", cli);
+        if (Boolean.parseBoolean(cli.getOrDefault("HELP", "false"))) {
+            printUsage();
+            return;
+        }
         cli.forEach(System::setProperty);
 
         EnvUtils.reload();
@@ -54,8 +58,24 @@ public class StreamBotApplication {
             } else if ("--setup".equals(args[i])) {
                 map.put("SETUP", "true");
                 logger.debug("Parsed setup flag");
+            } else if ("--help".equals(args[i])) {
+                map.put("HELP", "true");
+                logger.debug("Parsed help flag");
             }
         }
         return map;
+    }
+
+    private static void printUsage() {
+        String msg = String.join(System.lineSeparator(),
+                "Usage: java -jar streambot.jar [options]",
+                "  --api-key KEY       OpenAI API key",
+                "  --model MODEL       OpenAI model",
+                "  --tts-enabled VAL   enable text to speech",
+                "  --tts-voice VOICE   voice for synthesis",
+                "  --setup             run interactive setup",
+                "  --help              show this message",
+                "");
+        System.out.println(msg);
     }
 }

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -160,4 +160,22 @@ public class StreamBotApplicationTest {
             }
         }
     }
+
+    @Test
+    public void helpFlagPrintsUsage() throws Exception {
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream();
+        java.io.PrintStream origOut = System.out;
+        java.io.InputStream origIn = System.in;
+        try {
+            System.setOut(new java.io.PrintStream(out));
+            System.setIn(new ByteArrayInputStream(new byte[0]));
+            StreamBotApplication.main(new String[]{"--help"});
+        } finally {
+            System.setOut(origOut);
+            System.setIn(origIn);
+        }
+        String text = out.toString(java.nio.charset.StandardCharsets.UTF_8);
+        assertTrue(text.contains("--api-key"), "usage should mention api-key");
+        assertTrue(text.contains("--help"), "usage should mention help flag");
+    }
 }


### PR DESCRIPTION
## Summary
- support `--help` flag in `StreamBotApplication`
- show usage information when `--help` is provided
- document `--help` flag in README files
- test help output

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684b4a37a820832caf29faba83c42cbb