### PR TITLE
Switch suggestion prompt to Spanish

### DIFF
--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -96,13 +96,12 @@ public class LocalChatBot {
     private String buildSuggestionPrompt() {
         String style = config.getConversationStyle();
         List<String> topics = config.getTopics();
-        StringBuilder sb = new StringBuilder("Suggest a");
+        StringBuilder sb = new StringBuilder("Sugiere un tema de conversación");
         if (style != null && !style.isBlank() && !"neutral".equalsIgnoreCase(style)) {
             sb.append(' ').append(style);
         }
-        sb.append(" conversation topic");
         if (!topics.isEmpty()) {
-            sb.append(" about ").append(String.join(", ", topics));
+            sb.append(" sobre ").append(String.join(", ", topics));
         }
         sb.append('.');
         return sb.toString();

--- a/src/test/java/com/example/streambot/LocalChatBotTest.java
+++ b/src/test/java/com/example/streambot/LocalChatBotTest.java
@@ -65,7 +65,7 @@ public class LocalChatBotTest {
         }
 
         assertTrue(svc.closed, "service closed");
-        assertEquals(List.of("Suggest a casual conversation topic about science."), svc.received);
+        assertEquals(List.of("Sugiere un tema de conversación casual sobre science."), svc.received);
     }
 
 }


### PR DESCRIPTION
## Summary
- switch default conversation topic request to Spanish
- update unit test expectation accordingly

## Testing
- `mvn -q -o test`

------
https://chatgpt.com/codex/tasks/task_e_684b5918e3cc832c978b16f3d2b9ebc2