### PR TITLE
Add OPENAI_LANGUAGE variable and Spanish comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,18 +118,30 @@ Las principales variables de configuración son:
 Usa `env.example` como guía para crear tu propio `.env`:
 
 ```
-# Example configuration for StreamBot
+# Configuración de ejemplo para StreamBot
 OPENAI_API_KEY=
 OPENAI_MODEL=
+# Temperatura entre 0 y 2
 OPENAI_TEMPERATURE=
+# top_p para muestreo nucleus
 OPENAI_TOP_P=
+# Máximo de tokens por respuesta
 OPENAI_MAX_TOKENS=
+# Idioma para las respuestas (es, en, etc.)
+OPENAI_LANGUAGE=
+# Tono deseado para las sugerencias
 CONVERSATION_STYLE=
+# Temas separados por comas
 PREFERRED_TOPICS=
+# Segundos de silencio antes de sugerir un tema
 SILENCE_TIMEOUT=
+# Habilitar reproducción de texto a voz
 TTS_ENABLED=
+# Nombre de la voz para TTS (alloy, echo, fable, onyx, nova o shimmer)
 TTS_VOICE=
+# Monitorear actividad del micrófono para reiniciar el temporizador
 USE_MICROPHONE=
+# Nombre del dispositivo de micrófono (opcional)
 MICROPHONE_NAME=
 ```
 

--- a/env.example
+++ b/env.example
@@ -1,23 +1,25 @@
-# Example configuration for StreamBot
+# Configuración de ejemplo para StreamBot
 OPENAI_API_KEY=
 OPENAI_MODEL=
-# Temperature between 0 and 2
+# Temperatura entre 0 y 2
 OPENAI_TEMPERATURE=
-# nucleus sampling top_p
+# top_p para muestreo nucleus
 OPENAI_TOP_P=
-# Maximum tokens per response
+# Máximo de tokens por respuesta
 OPENAI_MAX_TOKENS=
-# Desired tone for suggestions
+# Idioma para las respuestas (es, en, etc.)
+OPENAI_LANGUAGE=
+# Tono deseado para las sugerencias
 CONVERSATION_STYLE=
-# Comma-separated topics
+# Temas separados por comas
 PREFERRED_TOPICS=
-# Seconds of silence before a suggestion
+# Segundos de silencio antes de sugerir un tema
 SILENCE_TIMEOUT=
-# Enable Text-to-Speech playback
+# Habilitar reproducción de texto a voz
 TTS_ENABLED=
-# Voice name for TTS (alloy, echo, fable, onyx, nova or shimmer)
+# Nombre de la voz para TTS (alloy, echo, fable, onyx, nova o shimmer)
 TTS_VOICE=
-# Monitor microphone activity to reset the silence timer
+# Monitorear actividad del micrófono para reiniciar el temporizador
 USE_MICROPHONE=
-# Optional microphone device name
+# Nombre del dispositivo de micrófono (opcional)
 MICROPHONE_NAME=


### PR DESCRIPTION
## Summary
- translate env.example comments to Spanish
- add OPENAI_LANGUAGE variable to env.example
- update example block in README with Spanish comments

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684c8e39e8f8832c808d33911c34fde7