### PR TITLE
Check TTS status before playback

### DIFF
--- a/src/main/java/com/example/streambot/SpeechService.java
+++ b/src/main/java/com/example/streambot/SpeechService.java
@@ -56,6 +56,11 @@ public class SpeechService {
                     .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
                     .build();
             HttpResponse<byte[]> resp = client.send(req, HttpResponse.BodyHandlers.ofByteArray());
+            int status = resp.statusCode();
+            if (status != 200) {
+                logger.error("Solicitud TTS falló con código {}", status);
+                return;
+            }
             byte[] audio = resp.body();
             try (ByteArrayInputStream bis = new ByteArrayInputStream(audio)) {
                 Player player = new Player(bis);


### PR DESCRIPTION
## Summary
- skip playback if the OpenAI TTS request does not return HTTP 200
- expose status code in the dummy HTTP response for testing
- test that playback is skipped on non-successful responses

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684d20eec724832ca74a162a5e88939f