### PR TITLE
Add error handling for non-200 OpenAI responses

### DIFF
--- a/src/main/java/com/example/streambot/OpenAIService.java
+++ b/src/main/java/com/example/streambot/OpenAIService.java
@@ -107,7 +107,12 @@ public class OpenAIService {
                     .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
                     .build();
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            logger.debug("Respuesta recibida con estado {}", response.statusCode());
+            int code = response.statusCode();
+            logger.debug("Respuesta recibida con estado {}", code);
+            if (code != 200) {
+                logger.error("Error en la llamada a OpenAI: {}", code);
+                return "";
+            }
             return parseContent(response.body());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/test/java/com/example/streambot/OpenAIServiceTest.java
+++ b/src/test/java/com/example/streambot/OpenAIServiceTest.java
@@ -28,10 +28,15 @@ public class OpenAIServiceTest {
 
     private static class SimpleResponse implements HttpResponse<String> {
         private final String body;
+        private final int status;
         SimpleResponse(String body) {
-            this.body = body;
+            this(body, 200);
         }
-        @Override public int statusCode() { return 200; }
+        SimpleResponse(String body, int status) {
+            this.body = body;
+            this.status = status;
+        }
+        @Override public int statusCode() { return status; }
         @Override public HttpRequest request() { return null; }
         @Override public Optional<HttpResponse<String>> previousResponse() { return Optional.empty(); }
         @Override public HttpHeaders headers() { return HttpHeaders.of(Map.of(), (a,b) -> true); }
@@ -108,6 +113,16 @@ public class OpenAIServiceTest {
         System.setProperty("OPENAI_API_KEY", "key");
         Config cfg = Config.load();
         OpenAIService svc = new OpenAIService(new StubHttpClient(new IOException("boom")), cfg);
+        String reply = svc.ask("hi");
+        assertEquals("", reply);
+    }
+
+    @Test
+    public void askReturnsEmptyOnNon200Status() {
+        System.setProperty("OPENAI_API_KEY", "key");
+        HttpResponse<String> resp = new SimpleResponse("{}", 500);
+        Config cfg = Config.load();
+        OpenAIService svc = new OpenAIService(new StubHttpClient(resp), cfg);
         String reply = svc.ask("hi");
         assertEquals("", reply);
     }


### PR DESCRIPTION
## Summary
- log and return empty string when OpenAI replies with a non-200 status
- extend `OpenAIServiceTest` to support variable statuses
- add test ensuring non-200 responses return empty strings

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684d21d0f3c0832cb6954475bb46a892