### PR TITLE
Ensure MicrophoneMonitor.start is idempotent

### DIFF
--- a/src/main/java/com/example/streambot/MicrophoneMonitor.java
+++ b/src/main/java/com/example/streambot/MicrophoneMonitor.java
@@ -19,6 +19,7 @@ public class MicrophoneMonitor implements Runnable {
     private final Thread thread;
     private final String deviceName;
     private volatile boolean running;
+    private volatile boolean started;
 
     public MicrophoneMonitor(Runnable onActivity) {
         this(onActivity, null);
@@ -31,8 +32,12 @@ public class MicrophoneMonitor implements Runnable {
     }
 
     /** Start capturing audio in a background thread. */
-    public void start() {
+    public synchronized void start() {
+        if (started || thread.isAlive()) {
+            return;
+        }
         running = true;
+        started = true;
         thread.start();
     }
 

--- a/src/test/java/com/example/streambot/MicrophoneMonitorTest.java
+++ b/src/test/java/com/example/streambot/MicrophoneMonitorTest.java
@@ -1,0 +1,20 @@
+package com.example.streambot;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for the MicrophoneMonitor utility. */
+public class MicrophoneMonitorTest {
+
+    @Test
+    public void startCanBeCalledTwice() {
+        MicrophoneMonitor mon = new MicrophoneMonitor(() -> {}) {
+            @Override
+            public void run() { /* no-op */ }
+        };
+
+        mon.start();
+        // second start should not throw IllegalThreadStateException
+        mon.start();
+        mon.stop();
+    }
+}


### PR DESCRIPTION
## Summary
- protect `MicrophoneMonitor.start()` from launching multiple times
- add a unit test that calls `start()` twice

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684d22dc5b44832c9e15755f8c3087e3