### PR TITLE
Remove duplicate property reset

### DIFF
--- a/src/test/java/com/example/streambot/SetupWizardTest.java
+++ b/src/test/java/com/example/streambot/SetupWizardTest.java
@@ -87,7 +87,6 @@ public class SetupWizardTest {
             System.clearProperty("TTS_VOICE");
             System.clearProperty("USE_MICROPHONE");
             System.clearProperty("MICROPHONE_NAME");
-            System.clearProperty("MICROPHONE_NAME");
             Files.deleteIfExists(env);
             if (existed) {
                 Files.move(backup, env);


### PR DESCRIPTION
## Summary
- clean up duplicate `System.clearProperty("MICROPHONE_NAME")` in `SetupWizardTest`

## Testing
- `mvn -q -Dtest=SetupWizardTest#runCreatesEnvFile test` *(fails: some tests don't finish)*

------
https://chatgpt.com/codex/tasks/task_e_684d2732d368832ca3f047d34edb8d22