### PR TITLE
Add push-to-talk listener

### DIFF
--- a/src/main/java/com/example/streambot/ChatBotController.java
+++ b/src/main/java/com/example/streambot/ChatBotController.java
@@ -1,0 +1,20 @@
+package com.example.streambot;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple controller placeholder to handle user speech transcripts.
+ */
+public class ChatBotController {
+    private static final Logger logger = LoggerFactory.getLogger(ChatBotController.class);
+
+    /**
+     * Handle transcribed user speech.
+     *
+     * @param transcript the recognized text from the microphone
+     */
+    public static void onUserSpeech(String transcript) {
+        logger.info("Transcribed speech: {}", transcript);
+    }
+}

--- a/src/main/java/com/example/streambot/PushToTalk.java
+++ b/src/main/java/com/example/streambot/PushToTalk.java
@@ -1,0 +1,42 @@
+package com.example.streambot;
+
+import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
+import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Listener that records audio while F12 is held down and processes the speech
+ * when released.
+ */
+public class PushToTalk implements NativeKeyListener {
+    private static final Logger logger = LoggerFactory.getLogger(PushToTalk.class);
+    private AudioRecorder recorder;
+    private boolean pushToTalkActive;
+
+    @Override
+    public void nativeKeyPressed(NativeKeyEvent e) {
+        if (e.getKeyCode() == NativeKeyEvent.VC_F12 && !pushToTalkActive) {
+            logger.debug("F12 pressed - starting recorder");
+            recorder = new AudioRecorder();
+            recorder.start();
+            pushToTalkActive = true;
+        }
+    }
+
+    @Override
+    public void nativeKeyReleased(NativeKeyEvent e) {
+        if (e.getKeyCode() == NativeKeyEvent.VC_F12 && pushToTalkActive) {
+            logger.debug("F12 released - stopping recorder");
+            byte[] audio = recorder != null ? recorder.stop() : new byte[0];
+            pushToTalkActive = false;
+            String transcript = SpeechToText.transcribe(audio);
+            ChatBotController.onUserSpeech(transcript);
+        }
+    }
+
+    @Override
+    public void nativeKeyTyped(NativeKeyEvent e) {
+        // No-op
+    }
+}

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -3,6 +3,10 @@ package com.example.streambot;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.github.kwhat.jnativehook.GlobalScreen;
+
+import com.example.streambot.PushToTalk;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +40,26 @@ public class StreamBotApplication {
 
         Config config = Config.load();
         LocalChatBot bot = new LocalChatBot(config);
+
+        PushToTalk ptt = null;
+        try {
+            GlobalScreen.registerNativeHook();
+            ptt = new PushToTalk();
+            GlobalScreen.addNativeKeyListener(ptt);
+        } catch (Throwable e) {
+            logger.warn("No se pudo registrar el hook global", e);
+        }
+
         bot.start();
+
+        if (ptt != null) {
+            try {
+                GlobalScreen.removeNativeKeyListener(ptt);
+                GlobalScreen.unregisterNativeHook();
+            } catch (Exception e) {
+                logger.warn("Error al desregistrar el hook global", e);
+            }
+        }
     }
 
     // Package-private for tests


### PR DESCRIPTION
## Summary
- add `PushToTalk` key listener based on JNativeHook
- log transcribed speech in new `ChatBotController`
- register/unregister key hook in `StreamBotApplication`

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684d307c382c832cb75277d521bd7572