### PR TITLE
Introduce ChatBotController

### DIFF
--- a/src/main/java/com/example/streambot/ChatBotController.java
+++ b/src/main/java/com/example/streambot/ChatBotController.java
@@ -3,18 +3,94 @@ package com.example.streambot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
 /**
- * Simple controller placeholder to handle user speech transcripts.
+ * Controller that handles interaction with the OpenAI API and manages
+ * silence monitoring.
  */
 public class ChatBotController {
     private static final Logger logger = LoggerFactory.getLogger(ChatBotController.class);
 
+    private final OpenAIService aiService;
+    private final SpeechService speechService;
+    private final Config config;
+    private final AtomicLong lastInput = new AtomicLong(System.currentTimeMillis());
+    private final Function<Runnable, MicrophoneMonitor> monitorFactory;
+    private ScheduledExecutorService scheduler;
+    private MicrophoneMonitor monitor;
+
+    public ChatBotController(OpenAIService service, Config config,
+                             Function<Runnable, MicrophoneMonitor> monitorFactory) {
+        this.aiService = service != null ? service : new OpenAIService(config);
+        this.config = config != null ? config : Config.load();
+        this.speechService = new SpeechService(this.config);
+        this.monitorFactory = monitorFactory;
+    }
+
+    /** Start monitoring for silence and microphone activity. */
+    public void start() {
+        long timeoutMillis = config.getSilenceTimeout() * 1000L;
+        scheduler = Executors.newSingleThreadScheduledExecutor();
+        Runnable silenceCheck = () -> {
+            long now = System.currentTimeMillis();
+            if (now - lastInput.get() >= timeoutMillis) {
+                String prompt = buildSuggestionPrompt();
+                logger.debug("Silencio detectado. Enviando indicación: {}", prompt);
+                String response = aiService.ask(prompt);
+                logger.debug("Sugerencia recibida: {}", response);
+                speechService.speak(response);
+                lastInput.set(now);
+            }
+        };
+        scheduler.scheduleAtFixedRate(silenceCheck, timeoutMillis, timeoutMillis, TimeUnit.MILLISECONDS);
+        if (config.isUseMicrophone() && monitorFactory != null) {
+            monitor = monitorFactory.apply(() -> lastInput.set(System.currentTimeMillis()));
+            monitor.start();
+        }
+    }
+
+    /** Stop any background resources. */
+    public void stop() {
+        if (monitor != null) {
+            monitor.stop();
+        }
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+        aiService.close();
+    }
+
     /**
-     * Handle transcribed user speech.
-     *
-     * @param transcript the recognized text from the microphone
+     * Handle transcribed user speech by sending it to OpenAI and speaking the reply.
      */
-    public static void onUserSpeech(String transcript) {
-        logger.info("Transcribed speech: {}", transcript);
+    public void onUserSpeech(String text) {
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        lastInput.set(System.currentTimeMillis());
+        logger.info("Transcribed speech: {}", text);
+        String response = aiService.ask(text);
+        logger.debug("Respuesta recibida: {}", response);
+        speechService.speak(response);
+    }
+
+    private String buildSuggestionPrompt() {
+        String style = config.getConversationStyle();
+        List<String> topics = config.getTopics();
+        StringBuilder sb = new StringBuilder("Sugiere un tema de conversación");
+        if (style != null && !style.isBlank() && !"neutral".equalsIgnoreCase(style)) {
+            sb.append(' ').append(style);
+        }
+        if (!topics.isEmpty()) {
+            sb.append(" sobre ").append(String.join(", ", topics));
+        }
+        sb.append('.');
+        return sb.toString();
     }
 }

--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -1,28 +1,23 @@
 package com.example.streambot;
 
-import java.util.List;
 import java.util.Scanner;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.example.streambot.MicrophoneMonitor;
-import com.example.streambot.SpeechService;
+import com.example.streambot.ChatBotController;
 
 /**
  * A simple console-based chatbot that interacts with the OpenAI API
  * without connecting to external chat services.
  */
 public class LocalChatBot {
-    private static final Logger logger = LoggerFactory.getLogger(LocalChatBot.class);
-    private final OpenAIService aiService;
-    private final Config config;
-    private final SpeechService speechService;
     
+    private static final Logger logger = LoggerFactory.getLogger(LocalChatBot.class);
+    private final Config config;
+    private final ChatBotController controller;
+        
     /** Factory method for creating microphone monitors. */
     protected MicrophoneMonitor createMonitor(Runnable callback) {
         return new MicrophoneMonitor(callback, config.getMicrophoneName());
@@ -50,41 +45,24 @@ public class LocalChatBot {
      * Create a bot with the given service and configuration. Primarily used for testing.
      */
     public LocalChatBot(OpenAIService service, Config config) {
-        this.aiService = service;
         this.config = config != null ? config : Config.load();
-        this.speechService = new SpeechService(this.config);
+        this.controller = new ChatBotController(service, this.config, this::createMonitor);
+    }
+
+    /** Access the underlying controller. */
+    public ChatBotController getController() {
+        return controller;
     }
 
     /**
      * Start a simple REPL that sends user input to OpenAI and prints the response.
      */
     public void start() {
-        long timeoutMillis = config.getSilenceTimeout() * 1000L;
-        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-        AtomicLong lastInput = new AtomicLong(System.currentTimeMillis());
-        MicrophoneMonitor monitor = null;
-        Runnable silenceCheck = () -> {
-            long now = System.currentTimeMillis();
-            if (now - lastInput.get() >= timeoutMillis) {
-                String prompt = buildSuggestionPrompt();
-                logger.debug("Silencio detectado. Enviando indicación: {}", prompt);
-                String response = aiService.ask(prompt);
-                logger.debug("Sugerencia recibida: {}", response);
-                System.out.println("AI: " + response);
-                speechService.speak(response);
-                lastInput.set(now);
-            }
-        };
-        scheduler.scheduleAtFixedRate(silenceCheck, timeoutMillis, timeoutMillis, TimeUnit.MILLISECONDS);
-        if (config.isUseMicrophone()) {
-            monitor = createMonitor(() -> lastInput.set(System.currentTimeMillis()));
-            monitor.start();
-        }
+        controller.start();
         try (Scanner scanner = new Scanner(System.in)) {
             logger.info("ChatBot iniciado. Escribe 'exit' para salir.");
             while (scanner.hasNextLine()) {
                 String input = scanner.nextLine().trim();
-                lastInput.set(System.currentTimeMillis());
                 if (input.equalsIgnoreCase("exit") || input.equalsIgnoreCase("quit")) {
                     break;
                 }
@@ -92,32 +70,12 @@ public class LocalChatBot {
                     continue;
                 }
                 logger.debug("Enviando indicación: {}", input);
-                String response = aiService.ask(input);
-                logger.debug("Respuesta recibida: {}", response);
-                System.out.println("AI: " + response);
-                speechService.speak(response);
+                controller.onUserSpeech(input);
             }
         } finally {
-            if (monitor != null) {
-                monitor.stop();
-            }
-            scheduler.shutdownNow();
-            aiService.close();
+            controller.stop();
             logger.debug("Servicio de ChatBot cerrado");
         }
     }
 
-    private String buildSuggestionPrompt() {
-        String style = config.getConversationStyle();
-        List<String> topics = config.getTopics();
-        StringBuilder sb = new StringBuilder("Sugiere un tema de conversación");
-        if (style != null && !style.isBlank() && !"neutral".equalsIgnoreCase(style)) {
-            sb.append(' ').append(style);
-        }
-        if (!topics.isEmpty()) {
-            sb.append(" sobre ").append(String.join(", ", topics));
-        }
-        sb.append('.');
-        return sb.toString();
-    }
 }

--- a/src/main/java/com/example/streambot/PushToTalk.java
+++ b/src/main/java/com/example/streambot/PushToTalk.java
@@ -4,6 +4,7 @@ import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
 import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.example.streambot.ChatBotController;
 
 /**
  * Listener that records audio while F12 is held down and processes the speech
@@ -11,8 +12,13 @@ import org.slf4j.LoggerFactory;
  */
 public class PushToTalk implements NativeKeyListener {
     private static final Logger logger = LoggerFactory.getLogger(PushToTalk.class);
+    private final ChatBotController controller;
     private AudioRecorder recorder;
     private boolean pushToTalkActive;
+
+    public PushToTalk(ChatBotController controller) {
+        this.controller = controller;
+    }
 
     @Override
     public void nativeKeyPressed(NativeKeyEvent e) {
@@ -31,7 +37,9 @@ public class PushToTalk implements NativeKeyListener {
             byte[] audio = recorder != null ? recorder.stop() : new byte[0];
             pushToTalkActive = false;
             String transcript = SpeechToText.transcribe(audio);
-            ChatBotController.onUserSpeech(transcript);
+            if (controller != null) {
+                controller.onUserSpeech(transcript);
+            }
         }
     }
 

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -44,7 +44,7 @@ public class StreamBotApplication {
         PushToTalk ptt = null;
         try {
             GlobalScreen.registerNativeHook();
-            ptt = new PushToTalk();
+            ptt = new PushToTalk(bot.getController());
             GlobalScreen.addNativeKeyListener(ptt);
         } catch (Throwable e) {
             logger.warn("No se pudo registrar el hook global", e);


### PR DESCRIPTION
## Summary
- create `ChatBotController` managing `OpenAIService`, `SpeechService` and silence monitor
- refactor `LocalChatBot` to use controller
- wire controller into `PushToTalk` and `StreamBotApplication`

## Testing
- `mvn -DskipTests compile`
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684d32d53d18832ca5bf55c456b3bff0