### PR TITLE
Instantiate ChatBotController earlier

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -8,6 +8,8 @@ StreamBot is a Java application built with Maven that uses the OpenAI API to gen
 
 - Java 17 (JDK 17)
 - Maven (optional, you can use the included `./mvnw` wrapper)
+- The push-to-talk feature relies on the `jnativehook` library, which Maven
+  downloads automatically.
 
 Install JDK 17 first and then proceed with Maven if you prefer not to use the wrapper.
 
@@ -63,6 +65,7 @@ When compiling with Maven the file `target/streambot-1.0-SNAPSHOT-shaded.jar` wi
 ./mvnw package
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
+Hold down **F12** while speaking. Recording stops when you release the key.
 Before running make sure the variables `OPENAI_API_KEY` and `OPENAI_MODEL` are present in your environment or defined in `.env`. They can also be provided as arguments `--api-key` and `--model`. By default the model `gpt-3.5-turbo` is used. You can enable speech synthesis with `--tts-enabled true` and choose the voice using `--tts-voice`. Use `--help` to list all options.
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Aplicación Java basada en Maven que utiliza la API de OpenAI para generar respu
 
 - Java 17 (JDK 17)
 - Maven (opcional, se puede usar el wrapper `./mvnw` incluido)
+- La función de "pulsar para hablar" utiliza la biblioteca `jnativehook`,
+  que se descarga automáticamente con Maven.
 
 Instale primero JDK 17 y luego proceda con la instalaci\u00f3n de Maven.
 
@@ -95,6 +97,9 @@ Ejecuta el bot y muestra las respuestas en la consola:
 ```bash
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
+
+Mantén pulsada la tecla **F12** para hablar. El audio se grabará
+mientras permanezca presionada y se enviará al soltarla.
 
 
 ## Configuración de la API de OpenAI

--- a/src/main/java/com/example/streambot/LocalChatBot.java
+++ b/src/main/java/com/example/streambot/LocalChatBot.java
@@ -49,6 +49,21 @@ public class LocalChatBot {
         this.controller = new ChatBotController(service, this.config, this::createMonitor);
     }
 
+    /**
+     * Create a bot using an already constructed controller.
+     */
+    public LocalChatBot(ChatBotController controller, Config config) {
+        this.config = config != null ? config : Config.load();
+        this.controller = controller != null
+                ? controller
+                : new ChatBotController(null, this.config, this::createMonitor);
+    }
+
+    /** Convenience constructor using the supplied controller. */
+    public LocalChatBot(ChatBotController controller) {
+        this(controller, Config.load());
+    }
+
     /** Access the underlying controller. */
     public ChatBotController getController() {
         return controller;

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -6,6 +6,8 @@ import java.util.Map;
 import com.github.kwhat.jnativehook.GlobalScreen;
 
 import com.example.streambot.PushToTalk;
+import com.example.streambot.ChatBotController;
+import com.example.streambot.MicrophoneMonitor;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,17 +41,18 @@ public class StreamBotApplication {
         }
 
         Config config = Config.load();
-        LocalChatBot bot = new LocalChatBot(config);
-
+        ChatBotController controller = new ChatBotController(null, config,
+                cb -> new MicrophoneMonitor(cb, config.getMicrophoneName()));
         PushToTalk ptt = null;
         try {
             GlobalScreen.registerNativeHook();
-            ptt = new PushToTalk(bot.getController());
+            ptt = new PushToTalk(controller);
             GlobalScreen.addNativeKeyListener(ptt);
         } catch (Throwable e) {
             logger.warn("No se pudo registrar el hook global", e);
         }
 
+        LocalChatBot bot = new LocalChatBot(controller, config);
         bot.start();
 
         if (ptt != null) {


### PR DESCRIPTION
## Summary
- instantiate `ChatBotController` in `main` and pass it to `PushToTalk`
- allow creating `LocalChatBot` with an existing controller
- document F12 push‑to‑talk usage in the READMEs
- mention `jnativehook` dependency

## Testing
- `mvn -q -DskipTests package`
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d36b30aa4832cabc6bfe029ee3934