### PR TITLE
Add configurable push-to-talk key

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -65,11 +65,11 @@ When compiling with Maven the file `target/streambot-1.0-SNAPSHOT-shaded.jar` wi
 ./mvnw package
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
-Hold down **F12** while speaking. Recording stops when you release the key.
-Before running make sure the variables `OPENAI_API_KEY` and `OPENAI_MODEL` are present in your environment or defined in `.env`. They can also be provided as arguments `--api-key` and `--model`. By default the model `gpt-3.5-turbo` is used. You can enable speech synthesis with `--tts-enabled true` and choose the voice using `--tts-voice`. Use `--help` to list all options.
+Hold down **F12** while speaking. Recording stops when you release the key. The key can be changed with `--push-key` or the `PUSH_KEY` variable.
+Before running make sure the variables `OPENAI_API_KEY` and `OPENAI_MODEL` are present in your environment or defined in `.env`. They can also be provided as arguments `--api-key` and `--model`. By default the model `gpt-3.5-turbo` is used. You can enable speech synthesis with `--tts-enabled true`, choose the voice using `--tts-voice`, and set the push-to-talk key with `--push-key`. Use `--help` to list all options.
 
 ## Configuration
-Sign up at [OpenAI](https://platform.openai.com/) and create a new *API key*. Copy it to the `.env` file as the value for `OPENAI_API_KEY`. You can indicate the model with `OPENAI_MODEL`. Supported models are `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` and `gpt-4-32k`. If `.env` does not exist, running the application will launch `SetupWizard`, an interactive assistant that requests the values and generates the file automatically. You can also provide these values using `--api-key` and `--model`. Speech can be enabled with `--tts-enabled` and the voice chosen with `--tts-voice`. Use `--setup` if you want to run the wizard again and overwrite the current configuration. The file `env.example` can be used as a template.
+Sign up at [OpenAI](https://platform.openai.com/) and create a new *API key*. Copy it to the `.env` file as the value for `OPENAI_API_KEY`. You can indicate the model with `OPENAI_MODEL`. Supported models are `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` and `gpt-4-32k`. If `.env` does not exist, running the application will launch `SetupWizard`, an interactive assistant that requests the values and generates the file automatically. You can also provide these values using `--api-key` and `--model`. Speech can be enabled with `--tts-enabled`, the voice chosen with `--tts-voice`, and the push-to-talk key set with `--push-key`. Use `--setup` if you want to run the wizard again and overwrite the current configuration. The file `env.example` can be used as a template.
 
 The main configuration variables are:
 
@@ -85,6 +85,7 @@ The main configuration variables are:
 - `TTS_VOICE`: voice to use for synthesis (`alloy`, `echo`, `fable`, `onyx`, `nova` or `shimmer`).
 - `USE_MICROPHONE`: set to `true` to reset the silence timer when sound is detected.
 - `MICROPHONE_NAME`: name of the microphone device to monitor (optional).
+- `PUSH_KEY`: key used for push-to-talk (default `F12`).
 
 Use `env.example` as a guide to create your own `.env`:
 ```text

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Al compilar con Maven se generar\u00e1 el archivo `target/streambot-1.0-SNAPSHOT
 ./mvnw package
 java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
-Antes de ejecutar asegúrate de que las variables `OPENAI_API_KEY` y `OPENAI_MODEL` estén disponibles en tu entorno o definidas en `.env`. También puedes pasarlas al iniciar la aplicación con los argumentos `--api-key` y `--model`. De forma predeterminada se usa `gpt-3.5-turbo` como modelo. Además es posible habilitar la síntesis de voz con `--tts-enabled true` y seleccionar la voz mediante `--tts-voice`. Usa `--help` para listar todas las opciones.
+Antes de ejecutar asegúrate de que las variables `OPENAI_API_KEY` y `OPENAI_MODEL` estén disponibles en tu entorno o definidas en `.env`. También puedes pasarlas al iniciar la aplicación con los argumentos `--api-key` y `--model`. De forma predeterminada se usa `gpt-3.5-turbo` como modelo. Además es posible habilitar la síntesis de voz con `--tts-enabled true`, seleccionar la voz mediante `--tts-voice` y elegir la tecla de activación con `--push-key`. Usa `--help` para listar todas las opciones.
 
 ## Ejecutar pruebas
 Para correr las pruebas unitarias con Maven utilice:
@@ -99,11 +99,12 @@ java -jar target/streambot-1.0-SNAPSHOT-shaded.jar
 ```
 
 Mantén pulsada la tecla **F12** para hablar. El audio se grabará
-mientras permanezca presionada y se enviará al soltarla.
+mientras permanezca presionada y se enviará al soltarla. Puedes cambiar
+la tecla con la opción `--push-key` o la variable `PUSH_KEY`.
 
 
 ## Configuración de la API de OpenAI
-Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL`. Los modelos soportados son `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` y `gpt-4-32k` (estos valores se mostrarán cuando `SetupWizard` pregunte por `OPENAI_MODEL`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard`, un asistente interactivo que solicitará los valores y generará el archivo automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes habilitar la síntesis con `--tts-enabled` y elegir la voz con `--tts-voice`. Usa `--setup` si deseas volver a ejecutar el asistente y sobrescribir la configuración actual. Puedes usar `env.example` como plantilla.
+Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL`. Los modelos soportados son `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` y `gpt-4-32k` (estos valores se mostrarán cuando `SetupWizard` pregunte por `OPENAI_MODEL`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard`, un asistente interactivo que solicitará los valores y generará el archivo automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes habilitar la síntesis con `--tts-enabled` y elegir la voz con `--tts-voice` y definir la tecla con `--push-key`. Usa `--setup` si deseas volver a ejecutar el asistente y sobrescribir la configuración actual. Puedes usar `env.example` como plantilla.
 
 Las principales variables de configuración son:
 
@@ -120,6 +121,7 @@ Las principales variables de configuración son:
 - `TTS_VOICE`: voz a utilizar para la síntesis (`alloy`, `echo`, `fable`, `onyx`, `nova` o `shimmer`).
 - `USE_MICROPHONE`: establece `true` para tener en cuenta el micrófono y reiniciar el temporizador de silencio cuando se detecte sonido.
 - `MICROPHONE_NAME`: nombre del dispositivo de micrófono a utilizar (opcional).
+- `PUSH_KEY`: tecla para pulsar y hablar (por defecto `F12`).
 
 Usa `env.example` como guía para crear tu propio `.env`:
 

--- a/env.example
+++ b/env.example
@@ -23,3 +23,5 @@ TTS_VOICE=
 USE_MICROPHONE=
 # Nombre del dispositivo de micrófono (opcional)
 MICROPHONE_NAME=
+# Tecla para pulsar para hablar (por defecto F12)
+PUSH_KEY=

--- a/src/main/java/com/example/streambot/PushToTalk.java
+++ b/src/main/java/com/example/streambot/PushToTalk.java
@@ -13,16 +13,18 @@ import com.example.streambot.ChatBotController;
 public class PushToTalk implements NativeKeyListener {
     private static final Logger logger = LoggerFactory.getLogger(PushToTalk.class);
     private final ChatBotController controller;
+    private final int pushKeyCode;
     private AudioRecorder recorder;
 
-    public PushToTalk(ChatBotController controller) {
+    public PushToTalk(ChatBotController controller, int pushKeyCode) {
         this.controller = controller;
+        this.pushKeyCode = pushKeyCode;
     }
 
     @Override
     public void nativeKeyPressed(NativeKeyEvent e) {
-        if (e.getKeyCode() == NativeKeyEvent.VC_F12 && !controller.pushToTalkActive) {
-            logger.debug("F12 pressed - starting recorder");
+        if (e.getKeyCode() == pushKeyCode && !controller.pushToTalkActive) {
+            logger.debug("push key pressed - starting recorder");
             recorder = new AudioRecorder();
             recorder.start();
             controller.pushToTalkActive = true;
@@ -31,8 +33,8 @@ public class PushToTalk implements NativeKeyListener {
 
     @Override
     public void nativeKeyReleased(NativeKeyEvent e) {
-        if (e.getKeyCode() == NativeKeyEvent.VC_F12 && controller.pushToTalkActive) {
-            logger.debug("F12 released - stopping recorder");
+        if (e.getKeyCode() == pushKeyCode && controller.pushToTalkActive) {
+            logger.debug("push key released - stopping recorder");
             byte[] audio = recorder != null ? recorder.stop() : new byte[0];
             controller.pushToTalkActive = false;
             String transcript = SpeechToText.transcribe(audio);

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -46,7 +46,7 @@ public class StreamBotApplication {
         PushToTalk ptt = null;
         try {
             GlobalScreen.registerNativeHook();
-            ptt = new PushToTalk(controller);
+            ptt = new PushToTalk(controller, config.getPushKeyCode());
             GlobalScreen.addNativeKeyListener(ptt);
         } catch (Throwable e) {
             logger.warn("No se pudo registrar el hook global", e);
@@ -81,6 +81,9 @@ public class StreamBotApplication {
             } else if ("--tts-voice".equals(args[i]) && i + 1 < args.length) {
                 map.put("TTS_VOICE", args[++i]);
                     logger.debug("TTS_VOICE obtenido de CLI: {}", map.get("TTS_VOICE"));
+            } else if ("--push-key".equals(args[i]) && i + 1 < args.length) {
+                map.put("PUSH_KEY", args[++i]);
+                    logger.debug("PUSH_KEY obtenido de CLI: {}", map.get("PUSH_KEY"));
             } else if ("--setup".equals(args[i])) {
                 map.put("SETUP", "true");
                     logger.debug("Bandera de configuración detectada");
@@ -99,6 +102,7 @@ public class StreamBotApplication {
                 "  --model MODELO       modelo de OpenAI",
                 "  --tts-enabled VAL   habilitar texto a voz",
                 "  --tts-voice VOZ   voz para la síntesis",
+                "  --push-key TECLA   tecla para hablar",
                 "  --setup             ejecutar configuración interactiva",
                 "  --help              mostrar este mensaje",
                 "");

--- a/src/test/java/com/example/streambot/ConfigTest.java
+++ b/src/test/java/com/example/streambot/ConfigTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -23,6 +24,7 @@ public class ConfigTest {
         System.clearProperty("TTS_VOICE");
         System.clearProperty("USE_MICROPHONE");
         System.clearProperty("MICROPHONE_NAME");
+        System.clearProperty("PUSH_KEY");
     }
 
     @Test
@@ -39,6 +41,7 @@ public class ConfigTest {
         System.setProperty("TTS_VOICE", "onyx");
         System.setProperty("USE_MICROPHONE", "true");
         System.setProperty("MICROPHONE_NAME", "Test Mic");
+        System.setProperty("PUSH_KEY", "F11");
 
         Config cfg = Config.load();
         assertEquals("gpt-test", cfg.getModel());
@@ -53,6 +56,7 @@ public class ConfigTest {
         assertEquals("onyx", cfg.getTtsVoice());
         assertTrue(cfg.isUseMicrophone());
         assertEquals("Test Mic", cfg.getMicrophoneName());
+        assertEquals(NativeKeyEvent.VC_F11, cfg.getPushKeyCode());
     }
 
     @Test
@@ -70,6 +74,7 @@ public class ConfigTest {
         assertEquals("alloy", cfg.getTtsVoice());
         assertFalse(cfg.isUseMicrophone());
         assertEquals("", cfg.getMicrophoneName());
+        assertEquals(NativeKeyEvent.VC_F12, cfg.getPushKeyCode());
     }
 
     @Test

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -40,6 +40,12 @@ public class StreamBotApplicationTest {
     }
 
     @Test
+    public void parsesPushKeyFlag() {
+        Map<String, String> result = StreamBotApplication.parseArgs(new String[]{"--push-key", "F9"});
+        assertEquals("F9", result.get("PUSH_KEY"));
+    }
+
+    @Test
     public void parsesSetupFlag() {
         Map<String, String> result = StreamBotApplication.parseArgs(new String[]{"--setup"});
         assertEquals("true", result.get("SETUP"));
@@ -184,5 +190,6 @@ public class StreamBotApplicationTest {
         String text = out.toString(java.nio.charset.StandardCharsets.UTF_8);
         assertTrue(text.contains("--api-key"), "usage should mention api-key");
         assertTrue(text.contains("--help"), "usage should mention help flag");
+        assertTrue(text.contains("--push-key"), "usage should mention push key option");
     }
 }


### PR DESCRIPTION
## Summary
- let user configure the push-to-talk key
- support `--push-key` CLI flag and `PUSH_KEY` variable
- update PushToTalk to use the configured key
- document push key option in README files and env example
- test CLI flag, env variable, and configuration defaults

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_684d3b7f2378832c921da6b0c41e1bd7