### PR TITLE
Add language option to SetupWizard

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -70,6 +70,7 @@ Before running make sure the variables `OPENAI_API_KEY` and `OPENAI_MODEL` are p
 
 ## Configuration
 Sign up at [OpenAI](https://platform.openai.com/) and create a new *API key*. Copy it to the `.env` file as the value for `OPENAI_API_KEY`. You can indicate the model with `OPENAI_MODEL`. Supported models are `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` and `gpt-4-32k`. If `.env` does not exist, running the application will launch `SetupWizard`, an interactive assistant that requests the values and generates the file automatically. You can also provide these values using `--api-key` and `--model`. Speech can be enabled with `--tts-enabled`, the voice chosen with `--tts-voice`, and the push-to-talk key set with `--push-key`. Use `--setup` if you want to run the wizard again and overwrite the current configuration. The file `env.example` can be used as a template.
+Use `--lang en` or set `SETUP_LANG=en` to show the wizard prompts in English.
 
 The main configuration variables are:
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ la tecla con la opción `--push-key` o la variable `PUSH_KEY`.
 
 ## Configuración de la API de OpenAI
 Regístrate en [OpenAI](https://platform.openai.com/) y crea una nueva *API key*. Copia esa clave en el archivo `.env` como valor de `OPENAI_API_KEY`. Puedes indicar el modelo con `OPENAI_MODEL`. Los modelos soportados son `gpt-3.5-turbo`, `gpt-3.5-turbo-16k`, `gpt-4` y `gpt-4-32k` (estos valores se mostrarán cuando `SetupWizard` pregunte por `OPENAI_MODEL`). Si `.env` no existe, al ejecutar la aplicación se iniciará `SetupWizard`, un asistente interactivo que solicitará los valores y generará el archivo automáticamente. La clave ingresada quedará también disponible como propiedad del sistema para usarla de inmediato. Otra opción es pasar estos valores con los argumentos `--api-key` y `--model`. También puedes habilitar la síntesis con `--tts-enabled` y elegir la voz con `--tts-voice` y definir la tecla con `--push-key`. Usa `--setup` si deseas volver a ejecutar el asistente y sobrescribir la configuración actual. Puedes usar `env.example` como plantilla.
+Para mostrar las preguntas del asistente en inglés, ejecuta `--lang en` o define la variable `SETUP_LANG=en`.
 
 Las principales variables de configuración son:
 

--- a/src/main/java/com/example/streambot/SetupWizard.java
+++ b/src/main/java/com/example/streambot/SetupWizard.java
@@ -38,8 +38,10 @@ public class SetupWizard {
         File env = new File(".env");
 
         try (Scanner scanner = new Scanner(System.in)) {
-            logger.info("Iniciando asistente de configuración");
-            System.out.println("Configuraci\u00f3n inicial de StreamBot:");
+            String lang = EnvUtils.get("SETUP_LANG", "es").toLowerCase();
+            boolean en = lang.startsWith("en");
+            logger.info(en ? "Starting setup wizard" : "Iniciando asistente de configuración");
+            System.out.println(en ? "Initial StreamBot setup:" : "Configuración inicial de StreamBot:");
             System.out.print("OPENAI_API_KEY: ");
             String key = scanner.nextLine().trim();
 
@@ -47,7 +49,7 @@ public class SetupWizard {
             String model = scanner.nextLine().trim();
             if (!SUPPORTED_MODELS.contains(model)) {
                 String def = SUPPORTED_MODELS.get(0);
-                System.out.println("Modelo no válido, se usará " + def);
+                System.out.println(en ? "Invalid model, using " + def : "Modelo no válido, se usará " + def);
                 logger.warn("Modelo no soportado '{}', se utilizará {}", model, def);
                 model = def;
             }
@@ -91,7 +93,7 @@ public class SetupWizard {
                 }
             }
             if (!micNames.isEmpty()) {
-                System.out.println("Micrófonos disponibles:");
+                System.out.println(en ? "Available microphones:" : "Micrófonos disponibles:");
                 for (String name : micNames) {
                     System.out.println("- " + name);
                 }
@@ -131,7 +133,7 @@ public class SetupWizard {
 
             EnvUtils.reload();
 
-            System.out.println("Archivo .env creado o actualizado.\n");
+            System.out.println(en ? ".env file created or updated.\n" : "Archivo .env creado o actualizado.\n");
             logger.info("Archivo .env creado o actualizado");
         } catch (IOException e) {
             logger.error("Error al crear .env", e);

--- a/src/main/java/com/example/streambot/StreamBotApplication.java
+++ b/src/main/java/com/example/streambot/StreamBotApplication.java
@@ -84,6 +84,9 @@ public class StreamBotApplication {
             } else if ("--push-key".equals(args[i]) && i + 1 < args.length) {
                 map.put("PUSH_KEY", args[++i]);
                     logger.debug("PUSH_KEY obtenido de CLI: {}", map.get("PUSH_KEY"));
+            } else if ("--lang".equals(args[i]) && i + 1 < args.length) {
+                map.put("SETUP_LANG", args[++i]);
+                    logger.debug("SETUP_LANG obtenido de CLI: {}", map.get("SETUP_LANG"));
             } else if ("--setup".equals(args[i])) {
                 map.put("SETUP", "true");
                     logger.debug("Bandera de configuración detectada");
@@ -103,6 +106,7 @@ public class StreamBotApplication {
                 "  --tts-enabled VAL   habilitar texto a voz",
                 "  --tts-voice VOZ   voz para la síntesis",
                 "  --push-key TECLA   tecla para hablar",
+                "  --lang CODIGO        idioma del asistente (es o en)",
                 "  --setup             ejecutar configuración interactiva",
                 "  --help              mostrar este mensaje",
                 "");

--- a/src/test/java/com/example/streambot/SetupWizardTest.java
+++ b/src/test/java/com/example/streambot/SetupWizardTest.java
@@ -184,4 +184,47 @@ public class SetupWizardTest {
             }
         }
     }
+
+    @Test
+    public void runRespectsLanguageProperty(@TempDir Path tmp) throws Exception {
+        Path env = Path.of(".env");
+        Path backup = tmp.resolve("env.bak");
+        boolean existed = Files.exists(env);
+        if (existed) {
+            Files.move(env, backup);
+        }
+        InputStream originalIn = System.in;
+        try {
+            String userInput = String.join("\n",
+                    "foo", "gpt-3.5-turbo", "0.5", "0.9", "100", "en", "formal",
+                    "", "10", "false", "alloy", "false", "USB", "");
+            System.setIn(new ByteArrayInputStream(userInput.getBytes(StandardCharsets.UTF_8)));
+            System.setProperty("SETUP_LANG", "en");
+            SetupWizard.run();
+            assertEquals("en", System.getProperty("OPENAI_LANGUAGE"));
+            assertTrue(Files.exists(env), ".env should exist");
+        } finally {
+            System.setIn(originalIn);
+            System.clearProperty("OPENAI_API_KEY");
+            System.clearProperty("OPENAI_MODEL");
+            System.clearProperty("OPENAI_TEMPERATURE");
+            System.clearProperty("OPENAI_TOP_P");
+            System.clearProperty("OPENAI_MAX_TOKENS");
+            System.clearProperty("OPENAI_LANGUAGE");
+            System.clearProperty("CONVERSATION_STYLE");
+            System.clearProperty("PREFERRED_TOPICS");
+            System.clearProperty("SILENCE_TIMEOUT");
+            System.clearProperty("TTS_ENABLED");
+            System.clearProperty("TTS_VOICE");
+            System.clearProperty("USE_MICROPHONE");
+            System.clearProperty("MICROPHONE_NAME");
+            System.clearProperty("SETUP_LANG");
+            Files.deleteIfExists(env);
+            if (existed) {
+                Files.move(backup, env);
+            } else {
+                Files.deleteIfExists(backup);
+            }
+        }
+    }
 }

--- a/src/test/java/com/example/streambot/StreamBotApplicationTest.java
+++ b/src/test/java/com/example/streambot/StreamBotApplicationTest.java
@@ -52,6 +52,12 @@ public class StreamBotApplicationTest {
     }
 
     @Test
+    public void parsesLangFlag() {
+        Map<String, String> result = StreamBotApplication.parseArgs(new String[]{"--lang", "en"});
+        assertEquals("en", result.get("SETUP_LANG"));
+    }
+
+    @Test
     public void mainSkipsWizardIfApiKeyProvided(@TempDir Path tmp) throws Exception {
         Path env = Path.of(".env");
         Path backup = tmp.resolve("env.bak");


### PR DESCRIPTION
## Summary
- allow choosing wizard prompts with `--lang` or `SETUP_LANG`
- show prompts in English when requested
- document how to select wizard language
- test new flag and environment property

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_684d3d5e2d14832c88d82d6790065298